### PR TITLE
Add NVIDIA NIM target model for GA fitness evaluation (#6)

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -5,6 +5,13 @@ improver:
   top_k: 3                              # number of top prompts fed to the improver
   n_variants: 3                         # improved variants generated per generation
 
+target_model:
+  model: meta/llama-3.3-70b-instruct    # fixed NIM model for fitness evaluation
+  temperature: 0                        # deterministic outputs
+  max_tokens: 512
+  retry_attempts: 3
+  retry_initial_backoff_seconds: 1.0
+
 ga:
   population_size: 20
   generations: 30

--- a/src/prompt.py
+++ b/src/prompt.py
@@ -31,6 +31,21 @@ class PromptTemplate:
             f"Function:\n{code}"
         )
 
+    def render_instructions(self) -> str:
+        """Render only the instruction components (role/task/guard/format).
+
+        Unlike :meth:`render`, this does not embed any code. It is intended for
+        callers (e.g. the GA fitness module, issue #7) that pass the
+        instructions as a system message and the code as a separate user
+        message to the target model.
+        """
+        return (
+            f"{self.role}\n\n"
+            f"{self.task}\n\n"
+            f"{self.guard}\n\n"
+            f"{self.format}"
+        )
+
     def to_dict(self) -> dict[str, str]:
         return asdict(self)
 

--- a/src/target_model.py
+++ b/src/target_model.py
@@ -170,7 +170,7 @@ def generate_summary(
                 "NVIDIA_API_KEY is not set. Add it to your .env file "
                 "(see .env.example)."
             )
-        client = openai.OpenAI(base_url=NIM_BASE_URL, api_key=api_key)
+        client = openai.OpenAI(base_url=NIM_BASE_URL, api_key=api_key, max_retries=0)
 
     messages = [
         {"role": "system", "content": prompt},

--- a/src/target_model.py
+++ b/src/target_model.py
@@ -1,0 +1,222 @@
+"""Fixed target model for the GA fitness evaluation loop.
+
+This module wraps the NVIDIA NIM OpenAI-compatible chat completions API and
+exposes a single function, :func:`generate_summary`, that the fitness module
+(issue #7) calls once per (function x candidate prompt) in the GA inner loop.
+
+The target model is held FIXED across the entire experiment -- only the
+prompt template evolves. Determinism (``temperature=0``) and reliability
+(retries with exponential backoff) are therefore important.
+
+Contract
+--------
+``generate_summary(prompt, code)`` builds the OpenAI messages list as::
+
+    [
+        {"role": "system", "content": prompt},
+        {"role": "user",   "content": code},
+    ]
+
+That is, ``prompt`` is the assembled instruction block (role/task/guard/
+format -- see :meth:`src.prompt.PromptTemplate.render_instructions`) and
+``code`` is the raw function body to summarize. Callers should NOT pre-embed
+the code in ``prompt``; pass the components separately.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+import time
+from pathlib import Path
+from typing import Any, Optional
+
+import openai
+from dotenv import load_dotenv
+
+NIM_BASE_URL = "https://integrate.api.nvidia.com/v1"
+DEFAULT_MODEL = "meta/llama-3.3-70b-instruct"
+DEFAULT_TEMPERATURE = 0.0
+DEFAULT_MAX_TOKENS = 512
+DEFAULT_RETRY_ATTEMPTS = 3
+DEFAULT_RETRY_INITIAL_BACKOFF = 1.0
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_DEFAULT_CONFIG_PATH = _REPO_ROOT / "config.yaml"
+
+logger = logging.getLogger(__name__)
+
+# Match a fenced code block at the start/end of the response, e.g.
+#     ```python\n...\n```
+# or  ```\n...\n```
+# Captures the inner content.
+_FENCE_BLOCK_RE = re.compile(
+    r"^\s*```[a-zA-Z0-9_+-]*\s*\n(?P<body>.*?)\n?```\s*$",
+    re.DOTALL,
+)
+
+
+def _load_target_config(config_path: Optional[Path] = None) -> dict[str, Any]:
+    """Lazily load the ``target_model`` section from ``config.yaml``.
+
+    Missing file or missing section -> empty dict (callers fall back to
+    module-level defaults). PyYAML import is also lazy so importing this
+    module does not require yaml at import time for callers that pass all
+    settings explicitly.
+    """
+    path = config_path or _DEFAULT_CONFIG_PATH
+    if not path.exists():
+        return {}
+    try:
+        import yaml  # type: ignore[import]
+    except ImportError:
+        return {}
+    try:
+        with path.open(encoding="utf-8") as fh:
+            data = yaml.safe_load(fh) or {}
+    except (OSError, yaml.YAMLError):
+        return {}
+    section = data.get("target_model") or {}
+    return section if isinstance(section, dict) else {}
+
+
+def _strip_markdown_fences(text: str) -> str:
+    """Remove a single surrounding markdown code fence and inline backticks.
+
+    Handles the two common shapes models produce:
+      - block fence:  ```lang\\n...\\n```
+      - inline fence: `...`
+    Any leading/trailing whitespace on the result is also stripped.
+    """
+    s = text.strip()
+    match = _FENCE_BLOCK_RE.match(s)
+    if match:
+        s = match.group("body").strip()
+    elif len(s) >= 2 and s.startswith("`") and s.endswith("`") and "\n" not in s:
+        # Inline single-backtick fence, e.g. `summary text`.
+        s = s[1:-1].strip()
+    return s
+
+
+def _is_transient_error(exc: BaseException) -> bool:
+    """Return True if ``exc`` is a transient error worth retrying.
+
+    Transient = network/connection error, rate limit, or HTTP 5xx. 4xx
+    surfaces immediately because retrying will not change the outcome.
+    """
+    if isinstance(exc, (openai.APIConnectionError, openai.APITimeoutError)):
+        return True
+    if isinstance(exc, openai.RateLimitError):
+        return True
+    if isinstance(exc, openai.APIStatusError):
+        return exc.status_code >= 500
+    return False
+
+
+def generate_summary(
+    prompt: str,
+    code: str,
+    *,
+    model: Optional[str] = None,
+    api_key: Optional[str] = None,
+    config_path: Optional[Path] = None,
+    client: Optional[Any] = None,
+) -> str:
+    """Call the NIM target model to produce a summary for ``code``.
+
+    Args:
+        prompt: Assembled instruction block (role/task/guard/format). Sent as
+            the ``system`` message. Does NOT need to embed the code.
+        code: Raw function body to summarize. Sent as the ``user`` message.
+        model: Override the model id; defaults to the value in
+            ``config.yaml``'s ``target_model.model`` section, or
+            :data:`DEFAULT_MODEL`.
+        api_key: Override the NVIDIA API key; defaults to the
+            ``NVIDIA_API_KEY`` environment variable (loaded from ``.env``).
+        config_path: Override the path to ``config.yaml`` (mainly for tests).
+        client: Optional pre-built OpenAI-compatible client (mainly for
+            tests). When provided, ``api_key`` is not required.
+
+    Returns:
+        The model's summary, with surrounding markdown code fences and
+        whitespace stripped.
+
+    Raises:
+        ValueError: ``NVIDIA_API_KEY`` is missing and no ``client`` was
+            provided.
+        openai.APIStatusError: HTTP 4xx response (surfaced immediately).
+        openai.APIError: After ``retry_attempts`` transient failures.
+    """
+    cfg = _load_target_config(config_path)
+    chosen_model = model or cfg.get("model") or DEFAULT_MODEL
+    temperature = cfg.get("temperature", DEFAULT_TEMPERATURE)
+    max_tokens = cfg.get("max_tokens", DEFAULT_MAX_TOKENS)
+    retry_attempts = int(cfg.get("retry_attempts", DEFAULT_RETRY_ATTEMPTS))
+    initial_backoff = float(
+        cfg.get("retry_initial_backoff_seconds", DEFAULT_RETRY_INITIAL_BACKOFF)
+    )
+    if retry_attempts < 1:
+        raise ValueError(
+            f"retry_attempts must be >= 1, got {retry_attempts}"
+        )
+
+    if client is None:
+        if api_key is None:
+            load_dotenv()
+            api_key = os.environ.get("NVIDIA_API_KEY")
+        if not api_key:
+            raise ValueError(
+                "NVIDIA_API_KEY is not set. Add it to your .env file "
+                "(see .env.example)."
+            )
+        client = openai.OpenAI(base_url=NIM_BASE_URL, api_key=api_key)
+
+    messages = [
+        {"role": "system", "content": prompt},
+        {"role": "user", "content": code},
+    ]
+
+    last_error: Optional[BaseException] = None
+    for attempt in range(1, retry_attempts + 1):
+        start = time.monotonic()
+        try:
+            response = client.chat.completions.create(
+                model=chosen_model,
+                messages=messages,
+                temperature=temperature,
+                max_tokens=max_tokens,
+            )
+        except openai.APIStatusError as exc:
+            elapsed = time.monotonic() - start
+            logger.debug(
+                "target_model call failed in %.3fs (attempt %d/%d): %s",
+                elapsed, attempt, retry_attempts, exc,
+            )
+            if not _is_transient_error(exc):
+                # 4xx -> surface immediately, no further retries.
+                raise
+            last_error = exc
+        except (openai.APIConnectionError, openai.APITimeoutError,
+                openai.RateLimitError) as exc:
+            elapsed = time.monotonic() - start
+            logger.debug(
+                "target_model call failed in %.3fs (attempt %d/%d): %s",
+                elapsed, attempt, retry_attempts, exc,
+            )
+            last_error = exc
+        else:
+            elapsed = time.monotonic() - start
+            logger.debug(
+                "target_model call succeeded in %.3fs (attempt %d/%d, model=%s)",
+                elapsed, attempt, retry_attempts, chosen_model,
+            )
+            raw = response.choices[0].message.content or ""
+            return _strip_markdown_fences(raw)
+
+        if attempt < retry_attempts:
+            sleep_for = initial_backoff * (2 ** (attempt - 1))
+            time.sleep(sleep_for)
+
+    assert last_error is not None
+    raise last_error

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -39,6 +39,25 @@ def test_render_preserves_component_order(sample_template: PromptTemplate) -> No
     assert positions == sorted(positions)
 
 
+def test_render_instructions_omits_code(sample_template: PromptTemplate) -> None:
+    instructions = sample_template.render_instructions()
+    code = "def add(a, b):\n    return a + b"
+    assert code not in instructions
+    assert "Function:" not in instructions
+    for field in COMPONENT_FIELDS:
+        assert getattr(sample_template, field) in instructions
+
+
+def test_render_instructions_preserves_component_order(
+    sample_template: PromptTemplate,
+) -> None:
+    instructions = sample_template.render_instructions()
+    positions = [
+        instructions.index(getattr(sample_template, f)) for f in COMPONENT_FIELDS
+    ]
+    assert positions == sorted(positions)
+
+
 def test_to_dict_roundtrip(sample_template: PromptTemplate) -> None:
     restored = PromptTemplate.from_dict(sample_template.to_dict())
     assert restored == sample_template

--- a/tests/test_target_model.py
+++ b/tests/test_target_model.py
@@ -1,0 +1,179 @@
+"""Tests for the NVIDIA NIM target model wrapper.
+
+All OpenAI calls are mocked -- no real network traffic. The fitness module
+(issue #7) will exercise this in integration; here we cover unit-level
+contract: response parsing, retry semantics, error surfacing, and logging.
+"""
+
+from __future__ import annotations
+
+import logging
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import httpx
+import openai
+import pytest
+
+from src import target_model
+
+
+def _make_response(content: str) -> SimpleNamespace:
+    """Build a fake OpenAI ChatCompletion response object."""
+    return SimpleNamespace(
+        choices=[SimpleNamespace(message=SimpleNamespace(content=content))]
+    )
+
+
+def _make_status_error(status_code: int) -> openai.APIStatusError:
+    """Construct an APIStatusError with the requested status_code.
+
+    The openai SDK's APIStatusError needs a Response to derive status_code,
+    so we build a stub httpx.Response.
+    """
+    request = httpx.Request("POST", "https://example.test/v1/chat/completions")
+    response = httpx.Response(status_code, request=request)
+    return openai.APIStatusError(
+        message=f"HTTP {status_code}",
+        response=response,
+        body=None,
+    )
+
+
+@pytest.fixture
+def fake_client() -> MagicMock:
+    client = MagicMock()
+    client.chat.completions.create = MagicMock()
+    return client
+
+
+def test_happy_path_strips_whitespace(fake_client: MagicMock) -> None:
+    fake_client.chat.completions.create.return_value = _make_response(
+        "  Adds two numbers and returns the result.   \n"
+    )
+    out = target_model.generate_summary(
+        "system instructions", "def add(a,b): return a+b", client=fake_client
+    )
+    assert out == "Adds two numbers and returns the result."
+    assert fake_client.chat.completions.create.call_count == 1
+
+
+def test_strips_python_fenced_block(fake_client: MagicMock) -> None:
+    fake_client.chat.completions.create.return_value = _make_response(
+        "```python\nReturns the sum of two integers.\n```"
+    )
+    out = target_model.generate_summary("p", "c", client=fake_client)
+    assert out == "Returns the sum of two integers."
+
+
+def test_strips_plain_fenced_block(fake_client: MagicMock) -> None:
+    fake_client.chat.completions.create.return_value = _make_response(
+        "```\nA short summary.\n```"
+    )
+    out = target_model.generate_summary("p", "c", client=fake_client)
+    assert out == "A short summary."
+
+
+def test_strips_inline_backticks(fake_client: MagicMock) -> None:
+    fake_client.chat.completions.create.return_value = _make_response(
+        "`inline summary`"
+    )
+    out = target_model.generate_summary("p", "c", client=fake_client)
+    assert out == "inline summary"
+
+
+def test_messages_use_system_user_split(fake_client: MagicMock) -> None:
+    fake_client.chat.completions.create.return_value = _make_response("ok")
+    target_model.generate_summary(
+        "INSTRUCTIONS", "CODE_BODY", client=fake_client
+    )
+    kwargs = fake_client.chat.completions.create.call_args.kwargs
+    assert kwargs["messages"] == [
+        {"role": "system", "content": "INSTRUCTIONS"},
+        {"role": "user", "content": "CODE_BODY"},
+    ]
+    # Determinism check.
+    assert kwargs["temperature"] == 0
+
+
+def test_retry_on_transient_then_succeeds(
+    fake_client: MagicMock, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # No real sleep between retries.
+    monkeypatch.setattr(target_model.time, "sleep", lambda _s: None)
+    fake_client.chat.completions.create.side_effect = [
+        _make_status_error(503),
+        _make_response("ok after retry"),
+    ]
+    out = target_model.generate_summary("p", "c", client=fake_client)
+    assert out == "ok after retry"
+    assert fake_client.chat.completions.create.call_count == 2
+
+
+def test_retry_exhausts_then_raises(
+    fake_client: MagicMock, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(target_model.time, "sleep", lambda _s: None)
+    err = _make_status_error(502)
+    fake_client.chat.completions.create.side_effect = [err, err, err]
+    with pytest.raises(openai.APIStatusError):
+        target_model.generate_summary("p", "c", client=fake_client)
+    assert fake_client.chat.completions.create.call_count == 3
+
+
+def test_4xx_surfaces_immediately(
+    fake_client: MagicMock, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(target_model.time, "sleep", lambda _s: None)
+    fake_client.chat.completions.create.side_effect = _make_status_error(400)
+    with pytest.raises(openai.APIStatusError) as excinfo:
+        target_model.generate_summary("p", "c", client=fake_client)
+    assert excinfo.value.status_code == 400
+    # Only one attempt -- 4xx is non-retryable.
+    assert fake_client.chat.completions.create.call_count == 1
+
+
+def test_connection_error_is_retried(
+    fake_client: MagicMock, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(target_model.time, "sleep", lambda _s: None)
+    request = httpx.Request("POST", "https://example.test/v1/chat/completions")
+    conn_err = openai.APIConnectionError(request=request)
+    fake_client.chat.completions.create.side_effect = [
+        conn_err,
+        _make_response("recovered"),
+    ]
+    out = target_model.generate_summary("p", "c", client=fake_client)
+    assert out == "recovered"
+    assert fake_client.chat.completions.create.call_count == 2
+
+
+def test_latency_logged_at_debug(
+    fake_client: MagicMock, caplog: pytest.LogCaptureFixture
+) -> None:
+    fake_client.chat.completions.create.return_value = _make_response("ok")
+    with caplog.at_level(logging.DEBUG, logger="src.target_model"):
+        target_model.generate_summary("p", "c", client=fake_client)
+    debug_records = [
+        r for r in caplog.records if r.levelno == logging.DEBUG
+    ]
+    assert any(
+        "target_model call succeeded" in r.getMessage() for r in debug_records
+    ), f"Expected a success debug log; got: {[r.getMessage() for r in debug_records]}"
+
+
+def test_missing_api_key_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("NVIDIA_API_KEY", raising=False)
+    # Stop python-dotenv from re-populating from a real .env on disk.
+    monkeypatch.setattr(target_model, "load_dotenv", lambda *a, **kw: None)
+    with pytest.raises(ValueError, match="NVIDIA_API_KEY"):
+        target_model.generate_summary("p", "c")
+
+
+def test_model_override_is_respected(fake_client: MagicMock) -> None:
+    fake_client.chat.completions.create.return_value = _make_response("ok")
+    target_model.generate_summary(
+        "p", "c", model="meta/some-other-model", client=fake_client
+    )
+    kwargs = fake_client.chat.completions.create.call_args.kwargs
+    assert kwargs["model"] == "meta/some-other-model"


### PR DESCRIPTION
Closes #6.

## Summary

- Adds `src/target_model.generate_summary(prompt, code)` -- the fixed NIM-backed model the GA fitness function (#7) calls once per (function x candidate prompt) pair. Held constant across the experiment; only the prompt template evolves.
- Wraps NIM's OpenAI-compatible chat completions endpoint via the `openai` SDK pointed at `https://integrate.api.nvidia.com/v1`.
- `temperature=0` for deterministic outputs; exponential-backoff retries (1s, 2s, 4s) on transient errors (network, timeout, rate limit, HTTP 5xx); 4xx surfaces immediately.
- Per-call latency logged at DEBUG via `logging` (no prints).
- Markdown code fences (block ```` ```...``` ```` and inline `` ` ``) stripped from responses; trailing/leading whitespace trimmed.
- New `target_model` section in `config.yaml` (model, temperature, max_tokens, retry_attempts, retry_initial_backoff_seconds). Read lazily.
- Mirrors `src/improver.py`'s NIM usage style. `improver.py` is untouched.

## Design decision: system/user message split

The issue specifies the signature `generate_summary(prompt: str, code: str) -> str`. Rather than concatenating the two into a single user message, this PR sends them as:

```python
[
    {"role": "system", "content": prompt},
    {"role": "user",   "content": code},
]
```

This is cleaner and gives the fitness module flexibility to hold instructions constant while only varying code per evaluation.

## New `PromptTemplate.render_instructions()` (caveat for #7)

`PromptTemplate.render(code)` already embeds the code in the assembled prompt -- so calling `generate_summary(template.render(code), code)` would send the code twice. To fix this without breaking existing callers, this PR adds:

```python
PromptTemplate.render_instructions() -> str  # role + task + guard + format, NO code
```

`render(code)` is preserved as-is for logging / debugging.

**Issue #7 implementer:** call the target model as

```python
generate_summary(template.render_instructions(), code)
```

NOT `generate_summary(template.render(code), code)`.

## `.env.example`

Already contains `NVIDIA_API_KEY` -- no change needed.

## Test plan

- [x] `pytest tests/test_target_model.py tests/test_prompt.py -v` -> 25/25 pass locally
- [x] Tests mock `openai.OpenAI`; no network calls
- [x] Coverage: happy path, fence-stripping (python/plain/inline), system/user split + temperature=0, retry-then-succeed, retry exhaustion, 4xx no-retry, connection-error retry, DEBUG latency log assertion, missing-API-key error, model override, `render_instructions()` omits code and preserves component order
- [ ] CI loop-tests job passes against Python 3.11 + full requirements