### PR TITLE
Add core Genetic Algorithm with tournament selection and elitism (#8)

### DIFF
--- a/src/ga.py
+++ b/src/ga.py
@@ -128,7 +128,10 @@ def _default_benchmark(
         p for p in functions_dir.iterdir()
         if p.is_file() and p.suffix in SUPPORTED_EXT
     )
-    refs_by_stem = {p.stem: p for p in references_dir.iterdir() if p.is_file()}
+    refs_by_stem = {
+        p.stem: p for p in references_dir.iterdir()
+        if p.is_file() and not p.name.startswith(".")
+    }
 
     fn_stems = {p.stem for p in functions}
     missing_refs = sorted(fn_stems - refs_by_stem.keys())
@@ -257,7 +260,11 @@ def run_ga(
 
     if bank is None:
         bank = load_component_bank()
-    if functions is None or references is None:
+    if (functions is None) != (references is None):
+        raise ValueError(
+            "functions and references must be provided together or both omitted"
+        )
+    if functions is None:
         functions, references = _default_benchmark()
 
     if output_dir is None:

--- a/src/ga.py
+++ b/src/ga.py
@@ -1,0 +1,329 @@
+"""Core Genetic Algorithm for prompt optimization (issue #8).
+
+The GA evolves a population of :class:`PromptTemplate` individuals using
+tournament selection, single-/two-field crossover, per-field mutation drawn
+from the component bank, and elitism. Each generation is scored in parallel
+via a thread pool because :func:`src.fitness.score_prompt` is dominated by
+target-model latency, not CPU.
+
+Determinism: every random choice flows through a single :class:`random.Random`
+seeded by the ``seed`` kwarg of :func:`run_ga`. Identical seed + identical
+``score_fn`` produce identical logs and identical winners.
+
+Coordination with issue #9 (Random Search): both algorithms emit the shared
+:class:`src.search_log.GenerationLog` schema so the analysis stage (issue #11)
+can load ``generations.jsonl`` uniformly without branching on algorithm.
+"""
+
+from __future__ import annotations
+
+import json
+import random
+from concurrent.futures import ThreadPoolExecutor
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Callable, Optional, Sequence
+
+from src.fitness import score_prompt as _default_score_prompt
+from src.prompt import COMPONENT_FIELDS, PromptTemplate, load_component_bank
+from src.search_log import GenerationLog, append_log
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_FUNCTIONS_DIR = REPO_ROOT / "data" / "functions"
+DEFAULT_REFERENCES_DIR = REPO_ROOT / "data" / "references"
+DEFAULT_RESULTS_DIR = REPO_ROOT / "results"
+
+ScoreFn = Callable[..., dict]
+
+
+# ---------------------------------------------------------------------------
+# Genetic operators (exposed for direct unit testing)
+# ---------------------------------------------------------------------------
+
+
+def random_template(bank: dict[str, list[str]], rng: random.Random) -> PromptTemplate:
+    """Sample one component per field uniformly at random from the bank."""
+    return PromptTemplate(**{f: rng.choice(bank[f]) for f in COMPONENT_FIELDS})
+
+
+def crossover(
+    parent_a: PromptTemplate,
+    parent_b: PromptTemplate,
+    rng: random.Random,
+) -> PromptTemplate:
+    """Swap a random subset of 1-2 component fields between two parents.
+
+    Returns a new ``PromptTemplate`` whose every field came from either
+    ``parent_a`` or ``parent_b``. The base parent is ``parent_a``; the
+    selected swap fields are taken from ``parent_b``.
+    """
+    n_swap = rng.randint(1, 2)
+    swap_fields = rng.sample(COMPONENT_FIELDS, n_swap)
+    values = {f: getattr(parent_a, f) for f in COMPONENT_FIELDS}
+    for f in swap_fields:
+        values[f] = getattr(parent_b, f)
+    return PromptTemplate(**values)
+
+
+def mutate(
+    template: PromptTemplate,
+    bank: dict[str, list[str]],
+    rng: random.Random,
+    p_mut: float,
+) -> PromptTemplate:
+    """Per-field mutation: with probability ``p_mut`` replace the component.
+
+    The replacement is drawn from the bank and is guaranteed to differ from
+    the current value when the bank holds more than one alternative.
+    """
+    values = {f: getattr(template, f) for f in COMPONENT_FIELDS}
+    for f in COMPONENT_FIELDS:
+        if rng.random() >= p_mut:
+            continue
+        choices = bank[f]
+        current = values[f]
+        if len(choices) > 1:
+            alternatives = [c for c in choices if c != current]
+            values[f] = rng.choice(alternatives)
+        else:
+            values[f] = choices[0]
+    return PromptTemplate(**values)
+
+
+def tournament_select(
+    population: list[PromptTemplate],
+    scores: list[float],
+    k: int,
+    rng: random.Random,
+) -> PromptTemplate:
+    """k-tournament: sample ``k`` individuals with replacement, return the best.
+
+    Ties are broken by the first occurrence (stable ``max``).
+    """
+    if not population:
+        raise ValueError("tournament_select called on empty population")
+    if k < 1:
+        raise ValueError(f"tournament_k must be >= 1, got {k}")
+    indices = [rng.randrange(len(population)) for _ in range(k)]
+    best_idx = max(indices, key=lambda i: scores[i])
+    return population[best_idx]
+
+
+# ---------------------------------------------------------------------------
+# Benchmark plumbing
+# ---------------------------------------------------------------------------
+
+
+def _default_benchmark(
+    functions_dir: Path = DEFAULT_FUNCTIONS_DIR,
+    references_dir: Path = DEFAULT_REFERENCES_DIR,
+) -> tuple[list[Path], list[Path]]:
+    """Pair every function file to its reference by stem.
+
+    Mirrors the strict pairing contract used by ``scripts/evaluate_best.py``:
+    any unpaired file raises so silent benchmark drift can't infect a run.
+    """
+    SUPPORTED_EXT = {".py", ".js", ".ts"}
+    functions = sorted(
+        p for p in functions_dir.iterdir()
+        if p.is_file() and p.suffix in SUPPORTED_EXT
+    )
+    refs_by_stem = {p.stem: p for p in references_dir.iterdir() if p.is_file()}
+
+    fn_stems = {p.stem for p in functions}
+    missing_refs = sorted(fn_stems - refs_by_stem.keys())
+    orphan_refs = sorted(refs_by_stem.keys() - fn_stems)
+
+    if missing_refs or orphan_refs:
+        details = []
+        if missing_refs:
+            preview = ", ".join(missing_refs[:5])
+            suffix = "..." if len(missing_refs) > 5 else ""
+            details.append(
+                f"{len(missing_refs)} function(s) missing references: {preview}{suffix}"
+            )
+        if orphan_refs:
+            preview = ", ".join(orphan_refs[:5])
+            suffix = "..." if len(orphan_refs) > 5 else ""
+            details.append(
+                f"{len(orphan_refs)} reference(s) without functions: {preview}{suffix}"
+            )
+        raise ValueError(
+            "benchmark pairing is incomplete; cannot run GA. "
+            + " | ".join(details)
+        )
+
+    paired_fn = list(functions)
+    paired_ref = [refs_by_stem[fn.stem] for fn in functions]
+    return paired_fn, paired_ref
+
+
+# ---------------------------------------------------------------------------
+# Main loop
+# ---------------------------------------------------------------------------
+
+
+def _evaluate_population(
+    population: list[PromptTemplate],
+    score_fn: ScoreFn,
+    functions: Sequence[Path],
+    references: Sequence[Path],
+    *,
+    generate_summary,
+    eval_subset: Optional[int],
+    seed: int,
+    workers: int,
+) -> list[dict]:
+    """Run ``score_fn`` over the population in parallel and return one dict per individual."""
+    def _eval(template: PromptTemplate) -> dict:
+        return score_fn(
+            template,
+            functions,
+            references,
+            generate_summary=generate_summary,
+            eval_subset=eval_subset,
+            seed=seed,
+        )
+
+    if workers <= 1 or len(population) <= 1:
+        return [_eval(t) for t in population]
+
+    with ThreadPoolExecutor(max_workers=workers) as ex:
+        return list(ex.map(_eval, population))
+
+
+def run_ga(
+    config: dict,
+    *,
+    score_fn: ScoreFn = _default_score_prompt,
+    generate_summary=None,
+    functions: Optional[Sequence[Path]] = None,
+    references: Optional[Sequence[Path]] = None,
+    output_dir: Optional[Path] = None,
+    seed: int = 0,
+    bank: Optional[dict[str, list[str]]] = None,
+) -> tuple[PromptTemplate, list[GenerationLog]]:
+    """Evolve a population of prompt templates with a tournament-elitism GA.
+
+    Args:
+        config: parsed ``config.yaml`` dict. Reads ``config["ga"]`` for
+            ``population_size``, ``generations``, ``elite_count``,
+            ``crossover_rate``, ``mutation_rate``, ``tournament_k`` and the
+            optional ``workers`` (default 8). Reads
+            ``config["evaluation"]["eval_subset"]`` for cheap inner-loop
+            evaluation; pass ``None`` for the full benchmark.
+        score_fn: pluggable fitness function with the same signature as
+            :func:`src.fitness.score_prompt`. Tests inject a deterministic
+            mock; production uses the real blended fitness.
+        generate_summary: forwarded to ``score_fn`` so callers can inject a
+            mock target model. Default ``None`` resolves to the NIM client
+            inside the fitness function.
+        functions / references: paired benchmark paths. Default to the full
+            500-file benchmark via :func:`_default_benchmark`.
+        output_dir: directory for ``generations.jsonl`` and ``best.json``.
+            Default ``results/ga_run_<UTC_timestamp>/``.
+        seed: master RNG seed; the same seed yields identical logs and the
+            identical best individual.
+        bank: component bank override (tests pass a tiny bank). Default
+            loads from ``data/component_bank.json``.
+
+    Returns:
+        ``(best_template, logs)`` where ``best_template`` is the highest
+        ``blended`` individual seen across the entire run (not just the last
+        generation) and ``logs`` has one entry per generation.
+    """
+    ga_cfg = config.get("ga", {}) or {}
+    eval_cfg = config.get("evaluation", {}) or {}
+
+    population_size = int(ga_cfg.get("population_size", 20))
+    generations_n = int(ga_cfg.get("generations", 30))
+    elite_count = int(ga_cfg.get("elite_count", 2))
+    crossover_rate = float(ga_cfg.get("crossover_rate", 0.7))
+    mutation_rate = float(ga_cfg.get("mutation_rate", 0.3))
+    tournament_k = int(ga_cfg.get("tournament_k", 3))
+    workers = int(ga_cfg.get("workers", min(population_size, 8)))
+    eval_subset = eval_cfg.get("eval_subset")
+    if eval_subset is not None:
+        eval_subset = int(eval_subset)
+
+    if population_size < 1:
+        raise ValueError(f"population_size must be >= 1, got {population_size}")
+    if generations_n < 1:
+        raise ValueError(f"generations must be >= 1, got {generations_n}")
+    if elite_count < 0 or elite_count > population_size:
+        raise ValueError(
+            f"elite_count must be in [0, population_size]; got {elite_count}"
+        )
+
+    if bank is None:
+        bank = load_component_bank()
+    if functions is None or references is None:
+        functions, references = _default_benchmark()
+
+    if output_dir is None:
+        timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+        output_dir = DEFAULT_RESULTS_DIR / f"ga_run_{timestamp}"
+    output_dir = Path(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    log_path = output_dir / "generations.jsonl"
+    best_path = output_dir / "best.json"
+
+    rng = random.Random(seed)
+
+    population: list[PromptTemplate] = [
+        random_template(bank, rng) for _ in range(population_size)
+    ]
+
+    logs: list[GenerationLog] = []
+    best_overall: tuple[Optional[PromptTemplate], Optional[dict]] = (None, None)
+
+    for gen in range(generations_n):
+        scores = _evaluate_population(
+            population,
+            score_fn,
+            functions,
+            references,
+            generate_summary=generate_summary,
+            eval_subset=eval_subset,
+            seed=seed,
+            workers=workers,
+        )
+        scored = list(zip(population, scores))
+
+        log = GenerationLog.from_population(gen, scored)
+        logs.append(log)
+        append_log(log_path, log)
+
+        # Track the all-time best so a single great individual lost to a
+        # mutation in a later generation isn't forgotten.
+        gen_best_t, gen_best_s = max(scored, key=lambda x: x[1]["blended"])
+        if best_overall[1] is None or gen_best_s["blended"] > best_overall[1]["blended"]:
+            best_overall = (gen_best_t, gen_best_s)
+
+        if gen == generations_n - 1:
+            break
+
+        # Elitism: top-E preserved unchanged into the next population.
+        ranked = sorted(scored, key=lambda x: x[1]["blended"], reverse=True)
+        elites = [t for t, _ in ranked[:elite_count]]
+
+        blended_scores = [s["blended"] for s in scores]
+
+        next_pop: list[PromptTemplate] = list(elites)
+        while len(next_pop) < population_size:
+            parent_a = tournament_select(population, blended_scores, tournament_k, rng)
+            if rng.random() < crossover_rate:
+                parent_b = tournament_select(population, blended_scores, tournament_k, rng)
+                child = crossover(parent_a, parent_b, rng)
+            else:
+                child = parent_a
+            child = mutate(child, bank, rng, mutation_rate)
+            next_pop.append(child)
+
+        population = next_pop[:population_size]
+
+    assert best_overall[0] is not None  # generations_n >= 1 guaranteed
+    best_template = best_overall[0]
+    best_path.write_text(json.dumps(best_template.to_dict(), indent=2), encoding="utf-8")
+
+    return best_template, logs

--- a/src/search_log.py
+++ b/src/search_log.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+import json
+
+from src.prompt import PromptTemplate
+
+
+@dataclass(frozen=True)
+class GenerationLog:
+    """One row per generation (GA) or P-evaluation checkpoint (RS).
+
+    Both algorithms emit the same schema so results/<run>/generations.jsonl
+    can be loaded uniformly by the analysis stage (issue #11).
+    """
+    generation: int
+    best_blended: float
+    mean_blended: float
+    worst_blended: float
+    # Per-metric breakdown of the best individual at this checkpoint
+    best_rouge_l: float
+    best_cosine_raw: float
+    best_cosine_calibrated: float
+    best_template: dict  # PromptTemplate.to_dict()
+
+    @classmethod
+    def from_population(cls, generation: int, scored: list[tuple["PromptTemplate", dict]]) -> "GenerationLog":
+        """Build a log row from a list of (template, score_dict) pairs."""
+        scored_sorted = sorted(scored, key=lambda x: x[1]["blended"], reverse=True)
+        best_t, best_s = scored_sorted[0]
+        blended = [s["blended"] for _, s in scored_sorted]
+        return cls(
+            generation=generation,
+            best_blended=best_s["blended"],
+            mean_blended=sum(blended) / len(blended),
+            worst_blended=blended[-1],
+            best_rouge_l=best_s["rouge_l"],
+            best_cosine_raw=best_s["cosine_raw"],
+            best_cosine_calibrated=best_s["cosine_calibrated"],
+            best_template=best_t.to_dict(),
+        )
+
+    def to_jsonl(self) -> str:
+        return json.dumps(asdict(self))
+
+
+def append_log(path: Path, log: GenerationLog) -> None:
+    """Append one log row to a JSONL file, flushing immediately."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "a", encoding="utf-8") as f:
+        f.write(log.to_jsonl() + "\n")
+        f.flush()

--- a/tests/test_ga.py
+++ b/tests/test_ga.py
@@ -1,0 +1,392 @@
+"""Tests for src/ga.py.
+
+Fitness is mocked end-to-end (no API, no embedder) via the ``score_fn``
+dependency-injection kwarg on :func:`run_ga`. The mock rewards a specific
+``role`` value so we can assert the GA actually converges instead of merely
+returning *something*.
+"""
+
+from __future__ import annotations
+
+import json
+import random
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+from src.ga import (
+    _default_benchmark,
+    crossover,
+    mutate,
+    random_template,
+    run_ga,
+    tournament_select,
+)
+from src.prompt import COMPONENT_FIELDS, PromptTemplate
+from src.search_log import GenerationLog
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+TARGET_ROLE = "You are a senior engineer."
+
+
+@pytest.fixture
+def tiny_bank() -> dict[str, list[str]]:
+    """A bank with multiple alternatives per field so mutation has options."""
+    return {
+        "role": [
+            TARGET_ROLE,
+            "You are a junior engineer.",
+            "You are a product manager.",
+            "You are a designer.",
+        ],
+        "task": [f"task_{i}" for i in range(4)],
+        "guard": [f"guard_{i}" for i in range(4)],
+        "format": [f"format_{i}" for i in range(4)],
+    }
+
+
+@pytest.fixture
+def benchmark_paths(tmp_path: Path) -> tuple[list[Path], list[Path]]:
+    """A trivial paired benchmark; the mock fitness ignores its contents."""
+    fn_dir = tmp_path / "functions"
+    ref_dir = tmp_path / "references"
+    fn_dir.mkdir()
+    ref_dir.mkdir()
+    fns, refs = [], []
+    for i in range(2):
+        fn = fn_dir / f"f_{i}.js"
+        rf = ref_dir / f"f_{i}.txt"
+        fn.write_text("function f(){}", encoding="utf-8")
+        rf.write_text("trivial", encoding="utf-8")
+        fns.append(fn)
+        refs.append(rf)
+    return fns, refs
+
+
+def _mock_score(template: PromptTemplate, functions, references, **kwargs) -> dict:
+    """Reward `TARGET_ROLE`; punish everything else. No I/O, fast, deterministic."""
+    blended = 0.9 if template.role == TARGET_ROLE else 0.1
+    return {
+        "blended": blended,
+        "rouge_l": blended,
+        "cosine_raw": blended,
+        "cosine_calibrated": blended,
+        "length_penalty": 0.0,
+        "format_penalty": 0.0,
+    }
+
+
+def _config(**ga_overrides) -> dict:
+    base = {
+        "ga": {
+            "population_size": 8,
+            "generations": 4,
+            "elite_count": 2,
+            "crossover_rate": 0.7,
+            "mutation_rate": 0.3,
+            "tournament_k": 3,
+            "workers": 1,  # serial for deterministic test ordering
+        },
+        "evaluation": {"eval_subset": None},
+    }
+    base["ga"].update(ga_overrides)
+    return base
+
+
+# ---------------------------------------------------------------------------
+# random_template
+# ---------------------------------------------------------------------------
+
+
+def test_random_template_uses_only_bank_entries(tiny_bank) -> None:
+    rng = random.Random(0)
+    for _ in range(50):
+        t = random_template(tiny_bank, rng)
+        for f in COMPONENT_FIELDS:
+            assert getattr(t, f) in tiny_bank[f]
+
+
+# ---------------------------------------------------------------------------
+# crossover
+# ---------------------------------------------------------------------------
+
+
+def test_crossover_fields_come_from_either_parent(tiny_bank) -> None:
+    rng = random.Random(1)
+    a = PromptTemplate(role="rA", task="tA", guard="gA", format="fA")
+    b = PromptTemplate(role="rB", task="tB", guard="gB", format="fB")
+    for _ in range(50):
+        child = crossover(a, b, rng)
+        for f in COMPONENT_FIELDS:
+            assert getattr(child, f) in {getattr(a, f), getattr(b, f)}
+
+
+def test_crossover_actually_swaps_at_least_one_field() -> None:
+    """Distinct parents → child must differ from parent_a in at least one field."""
+    rng = random.Random(2)
+    a = PromptTemplate(role="rA", task="tA", guard="gA", format="fA")
+    b = PromptTemplate(role="rB", task="tB", guard="gB", format="fB")
+    for _ in range(20):
+        child = crossover(a, b, rng)
+        assert child != a
+
+
+# ---------------------------------------------------------------------------
+# mutate
+# ---------------------------------------------------------------------------
+
+
+def test_mutate_p_zero_is_identity(tiny_bank) -> None:
+    rng = random.Random(3)
+    t = PromptTemplate(role=TARGET_ROLE, task="task_0", guard="guard_0", format="format_0")
+    assert mutate(t, tiny_bank, rng, p_mut=0.0) == t
+
+
+def test_mutate_p_one_changes_every_field(tiny_bank) -> None:
+    rng = random.Random(4)
+    t = PromptTemplate(role=TARGET_ROLE, task="task_0", guard="guard_0", format="format_0")
+    mutated = mutate(t, tiny_bank, rng, p_mut=1.0)
+    for f in COMPONENT_FIELDS:
+        assert getattr(mutated, f) != getattr(t, f)
+        assert getattr(mutated, f) in tiny_bank[f]
+
+
+def test_mutate_singleton_bank_is_identity() -> None:
+    """A field with only one alternative cannot mutate to a different value."""
+    bank = {f: ["only"] for f in COMPONENT_FIELDS}
+    rng = random.Random(5)
+    t = PromptTemplate(role="only", task="only", guard="only", format="only")
+    assert mutate(t, bank, rng, p_mut=1.0) == t
+
+
+# ---------------------------------------------------------------------------
+# tournament_select
+# ---------------------------------------------------------------------------
+
+
+def test_tournament_favors_higher_scores() -> None:
+    """Over many trials with k=3, the top-scored individual wins more often than the lowest."""
+    rng = random.Random(6)
+    pop = [PromptTemplate(role=str(i), task="t", guard="g", format="f") for i in range(5)]
+    scores = [0.1, 0.2, 0.3, 0.8, 0.9]  # idx 4 is best, idx 0 worst
+    wins = [0] * len(pop)
+    trials = 1000
+    for _ in range(trials):
+        winner = tournament_select(pop, scores, k=3, rng=rng)
+        wins[pop.index(winner)] += 1
+    # The two highest-scored should dominate the two lowest.
+    assert wins[4] + wins[3] > wins[0] + wins[1]
+    # Best should win a clear majority of single-best matchups vs worst.
+    assert wins[4] > wins[0] * 5
+
+
+def test_tournament_k_one_is_uniform_random() -> None:
+    """k=1 reduces to uniform sampling — every individual reachable."""
+    rng = random.Random(7)
+    pop = [PromptTemplate(role=str(i), task="t", guard="g", format="f") for i in range(4)]
+    scores = [0.0, 0.0, 0.0, 1.0]
+    seen = {tournament_select(pop, scores, k=1, rng=rng) for _ in range(200)}
+    assert seen == set(pop)
+
+
+# ---------------------------------------------------------------------------
+# run_ga: outputs, schema, evolution, reproducibility
+# ---------------------------------------------------------------------------
+
+
+def test_run_ga_writes_logs_and_best(tiny_bank, benchmark_paths, tmp_path) -> None:
+    fns, refs = benchmark_paths
+    out = tmp_path / "run"
+    config = _config(generations=3, population_size=6)
+
+    best, logs = run_ga(
+        config,
+        score_fn=_mock_score,
+        functions=fns,
+        references=refs,
+        bank=tiny_bank,
+        output_dir=out,
+        seed=0,
+    )
+
+    assert isinstance(best, PromptTemplate)
+    assert len(logs) == 3
+    assert all(isinstance(l, GenerationLog) for l in logs)
+
+    # generations.jsonl: one row per generation, each parses back to the schema.
+    log_path = out / "generations.jsonl"
+    assert log_path.exists()
+    rows = [json.loads(line) for line in log_path.read_text().splitlines() if line.strip()]
+    assert len(rows) == 3
+    expected_keys = {
+        "generation", "best_blended", "mean_blended", "worst_blended",
+        "best_rouge_l", "best_cosine_raw", "best_cosine_calibrated",
+        "best_template",
+    }
+    for row in rows:
+        assert set(row.keys()) == expected_keys
+        assert set(row["best_template"].keys()) == set(COMPONENT_FIELDS)
+
+    # best.json deserializes to a valid PromptTemplate.
+    best_path = out / "best.json"
+    assert best_path.exists()
+    restored = PromptTemplate.from_dict(json.loads(best_path.read_text()))
+    assert restored == best
+
+
+def test_run_ga_converges_toward_target_role(tiny_bank, benchmark_paths, tmp_path) -> None:
+    """With a fitness that strongly rewards a specific role, the GA should
+    surface the high-fitness role as the winner."""
+    fns, refs = benchmark_paths
+    config = _config(
+        population_size=10,
+        generations=8,
+        elite_count=2,
+        mutation_rate=0.2,
+        crossover_rate=0.7,
+    )
+
+    best, logs = run_ga(
+        config,
+        score_fn=_mock_score,
+        functions=fns,
+        references=refs,
+        bank=tiny_bank,
+        output_dir=tmp_path / "run",
+        seed=0,
+    )
+
+    # With elitism + selection pressure, the best at the final generation
+    # must be at least as good as at the first.
+    assert logs[-1].best_blended >= logs[0].best_blended
+    # And convergence: best individual carries the high-fitness role.
+    assert best.role == TARGET_ROLE
+    assert logs[-1].best_blended == pytest.approx(0.9)
+
+
+def test_run_ga_elitism_preserves_best(tiny_bank, benchmark_paths, tmp_path) -> None:
+    """best_blended is monotonically non-decreasing across generations when elite_count >= 1."""
+    fns, refs = benchmark_paths
+    config = _config(
+        population_size=8,
+        generations=6,
+        elite_count=2,
+        mutation_rate=0.5,  # high mutation to stress elitism
+        crossover_rate=0.7,
+    )
+    _, logs = run_ga(
+        config,
+        score_fn=_mock_score,
+        functions=fns,
+        references=refs,
+        bank=tiny_bank,
+        output_dir=tmp_path / "run",
+        seed=0,
+    )
+    best_curve = [l.best_blended for l in logs]
+    for prev, curr in zip(best_curve, best_curve[1:]):
+        assert curr >= prev, f"elitism violated: {best_curve}"
+
+
+def test_run_ga_is_reproducible(tiny_bank, benchmark_paths, tmp_path) -> None:
+    """Same seed → identical winner and identical generation logs."""
+    fns, refs = benchmark_paths
+    config = _config(generations=4, population_size=8)
+
+    best1, logs1 = run_ga(
+        config, score_fn=_mock_score, functions=fns, references=refs,
+        bank=tiny_bank, output_dir=tmp_path / "run1", seed=42,
+    )
+    best2, logs2 = run_ga(
+        config, score_fn=_mock_score, functions=fns, references=refs,
+        bank=tiny_bank, output_dir=tmp_path / "run2", seed=42,
+    )
+
+    assert best1 == best2
+    assert len(logs1) == len(logs2)
+    for a, b in zip(logs1, logs2):
+        assert a == b
+
+
+def test_run_ga_different_seeds_can_diverge(tiny_bank, benchmark_paths, tmp_path) -> None:
+    """Sanity: seeded RNG actually drives variation (otherwise reproducibility is vacuous)."""
+    fns, refs = benchmark_paths
+    config = _config(generations=2, population_size=6, mutation_rate=0.5)
+
+    _, logs1 = run_ga(
+        config, score_fn=_mock_score, functions=fns, references=refs,
+        bank=tiny_bank, output_dir=tmp_path / "a", seed=1,
+    )
+    _, logs2 = run_ga(
+        config, score_fn=_mock_score, functions=fns, references=refs,
+        bank=tiny_bank, output_dir=tmp_path / "b", seed=2,
+    )
+    # At least one row should differ across runs with different seeds.
+    assert any(a != b for a, b in zip(logs1, logs2))
+
+
+def test_run_ga_threadpool_path(tiny_bank, benchmark_paths, tmp_path) -> None:
+    """workers > 1 exercises the ThreadPoolExecutor branch and still returns a valid run."""
+    fns, refs = benchmark_paths
+    config = _config(workers=4, population_size=6, generations=2)
+    best, logs = run_ga(
+        config, score_fn=_mock_score, functions=fns, references=refs,
+        bank=tiny_bank, output_dir=tmp_path / "run", seed=0,
+    )
+    assert isinstance(best, PromptTemplate)
+    assert len(logs) == 2
+
+
+# ---------------------------------------------------------------------------
+# _default_benchmark
+# ---------------------------------------------------------------------------
+
+
+def test_default_benchmark_pairs_by_stem(tmp_path: Path) -> None:
+    fn_dir = tmp_path / "functions"
+    ref_dir = tmp_path / "references"
+    fn_dir.mkdir()
+    ref_dir.mkdir()
+    (fn_dir / "a.js").write_text("function a(){}")
+    (fn_dir / "b.py").write_text("def b(): pass")
+    (ref_dir / "a.txt").write_text("ref a")
+    (ref_dir / "b.txt").write_text("ref b")
+
+    fns, refs = _default_benchmark(fn_dir, ref_dir)
+    assert [p.stem for p in fns] == [p.stem for p in refs]
+    assert len(fns) == 2
+
+
+def test_default_benchmark_raises_on_unpaired_function(tmp_path: Path) -> None:
+    fn_dir = tmp_path / "functions"
+    ref_dir = tmp_path / "references"
+    fn_dir.mkdir()
+    ref_dir.mkdir()
+    (fn_dir / "a.js").write_text("function a(){}")
+    (fn_dir / "orphan.py").write_text("def b(): pass")
+    (ref_dir / "a.txt").write_text("ref a")
+
+    with pytest.raises(ValueError, match="missing references"):
+        _default_benchmark(fn_dir, ref_dir)
+
+
+def test_default_benchmark_raises_on_orphan_reference(tmp_path: Path) -> None:
+    fn_dir = tmp_path / "functions"
+    ref_dir = tmp_path / "references"
+    fn_dir.mkdir()
+    ref_dir.mkdir()
+    (fn_dir / "a.js").write_text("function a(){}")
+    (ref_dir / "a.txt").write_text("ref a")
+    (ref_dir / "orphan.txt").write_text("orphan")
+
+    with pytest.raises(ValueError, match="without functions"):
+        _default_benchmark(fn_dir, ref_dir)

--- a/tests/test_ga.py
+++ b/tests/test_ga.py
@@ -10,13 +10,9 @@ from __future__ import annotations
 
 import json
 import random
-import sys
 from pathlib import Path
 
 import pytest
-
-REPO_ROOT = Path(__file__).resolve().parent.parent
-sys.path.insert(0, str(REPO_ROOT))
 
 from src.ga import (
     _default_benchmark,


### PR DESCRIPTION
Closes #8.

## Summary
- Implements `src/ga.py:run_ga()` — tournament selection + elitism + 1-or-2-field crossover + per-field mutation, parallel fitness via `ThreadPoolExecutor`.
- Introduces `src/search_log.py:GenerationLog` — schema shared with Random Search (#9). Both algorithms emit identical JSONL so #11 can load results without branching. Expect a clean conflict-on-merge with #9 (\"identical, keep one\").
- Fitness is injected via `score_fn` kwarg (defaults to `src.fitness.score_prompt`) — explicit DI, fast tests, no monkey-patching.
- Reproducibility: every random choice flows through one seeded `random.Random`; same `seed` + same `score_fn` → byte-identical `generations.jsonl` + winner.
- Returns and serializes the **all-time best** (not just last-generation best) so a late mutation can't lose a strong individual found mid-run.
- 17 tests covering each operator individually (random init, crossover, mutation edge cases, tournament selection bias) plus `run_ga` end-to-end with the deterministic mock fitness from the spec — log schema, elitism monotonicity, seed reproducibility, divergence under different seeds, ThreadPool branch, strict-pairing benchmark errors.

## Operator details
- **Selection:** tournament with `k` from config (default 3). `k=1` degenerates to uniform random — covered by a test.
- **Crossover:** with prob `crossover_rate`, pick 1 or 2 component fields and swap them between two tournament-selected parents. Otherwise return parent A unchanged.
- **Mutation:** per component field, with prob `mutation_rate`, replace it with a different bank entry (singleton bank ⇒ identity, covered).
- **Elitism:** top `elite_count` individuals carry forward unchanged each generation.

## Reproducibility
Every random choice goes through a single `random.Random(seed)`. Same seed + same `score_fn` → identical `generations.jsonl`, identical winner, identical `best.json`. A test seeds two runs with the same value and asserts byte-equal logs; another test asserts different seeds can diverge.

## Coordination with #9
`src/search_log.py` is co-designed with PR #19 (Random Search). Both PRs create the file independently with identical content; the second to merge will hit a trivial conflict ('they're identical, keep one').

## Test plan
- [x] `pytest tests/test_ga.py -v` — 17 passed locally (mocked fitness, no API/embedder)
- [x] No regression in `tests/test_fitness.py` / `tests/test_prompt.py`
- [ ] Real end-to-end smoke deferred until both #8 and #9 land + #11 wires the orchestrator

🤖 Generated with [Claude Code](https://claude.com/claude-code)