### PR TITLE
Add experiment orchestration, Wilcoxon + Cliff's delta, convergence plot (#11)

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -32,3 +32,7 @@ fitness:
 
 evaluation:
   eval_subset: null   # null = use all 500 files; set to an int for fast inner-loop evals
+
+experiment:
+  trials: 10                              # independent runs per algorithm; >=10 keeps Wilcoxon credible
+  base_seed: 0                            # trial i uses seed = base_seed + i (matched across GA/RS)

--- a/config.yaml
+++ b/config.yaml
@@ -6,7 +6,7 @@ improver:
   n_variants: 3                         # improved variants generated per generation
 
 target_model:
-  model: nvidia/llama-3.3-nemotron-super-49b-v1   # fixed OpenRouter model for fitness evaluation; was nemotron-3-super-120b-a12b but ~11s/call extrapolated to ~9h experiment, swapped to the 49B variant for ~1-2h
+  model: nvidia/llama-3.3-nemotron-super-49b-v1.5   # fixed OpenRouter model for fitness evaluation; was nemotron-3-super-120b-a12b but ~11s/call extrapolated to ~9h experiment, swapped to the 49B v1.5 variant for ~1-2h
   temperature: 0                        # deterministic outputs
   max_tokens: 512
   retry_attempts: 3
@@ -32,7 +32,7 @@ fitness:
                          # scripts/calibrate_cosine_baseline.py.
 
 evaluation:
-  eval_subset: 10     # 10 functions per fitness call; set to null to use all 500 (final eval only)
+  eval_subset: 5    # 5 functions per fitness call; set to null to use all 500 (final eval only)
 
 experiment:
   trials: 10                              # independent runs per algorithm; >=10 keeps Wilcoxon credible

--- a/config.yaml
+++ b/config.yaml
@@ -15,14 +15,15 @@ target_model:
 ga:
   population_size: 12      # 
   generations: 15          #
-  elite_count: 2
+  elite_count: 3
   crossover_rate: 0.7
   mutation_rate: 0.3
   tournament_k: 3
   workers: 16              # parallel fitness evals per generation; bump higher only if OpenRouter doesn't 429
 
 fitness:
-  max_prompt_tokens: 200
+  max_prompt_tokens: 200             # length floor: penalty is 0 at or below this token count
+  length_penalty_exponent: 2.0       # past the floor, penalty grows as (excess / max_prompt_tokens) ** exponent. 1.0 = linear, 2.0 = quadratic (gentle right after the floor, steep far over). Set higher to tighten further.
   lambda_len: 0.1
   lambda_fmt: 0.2
   alpha: 0.3  # blend weight: alpha * ROUGE-L + (1 - alpha) * calibrated_cosine. Lowered from 0.5 because cosine catches semantically-equivalent paraphrases that ROUGE-L would punish — semantic match is a superset of the lexical match we actually care about, so weight it higher. ROUGE-L stays at 0.3 to anchor outputs to Opus's specific phrasing.

--- a/config.yaml
+++ b/config.yaml
@@ -6,15 +6,15 @@ improver:
   n_variants: 3                         # improved variants generated per generation
 
 target_model:
-  model: nvidia/nemotron-3-super-120b-a12b   # fixed OpenRouter model for fitness evaluation
+  model: nvidia/llama-3.3-nemotron-super-49b-v1   # fixed OpenRouter model for fitness evaluation; was nemotron-3-super-120b-a12b but ~11s/call extrapolated to ~9h experiment, swapped to the 49B variant for ~1-2h
   temperature: 0                        # deterministic outputs
   max_tokens: 512
   retry_attempts: 3
   retry_initial_backoff_seconds: 1.0
 
 ga:
-  population_size: 12      # was 20 — convergence on this small search space doesn't need 20
-  generations: 15          # was 30 — this space converges in ~10-15 anyway
+  population_size: 12      # 
+  generations: 15          #
   elite_count: 2
   crossover_rate: 0.7
   mutation_rate: 0.3

--- a/config.yaml
+++ b/config.yaml
@@ -25,7 +25,7 @@ fitness:
   max_prompt_tokens: 200
   lambda_len: 0.1
   lambda_fmt: 0.2
-  alpha: 0.5  # blend weight: alpha * ROUGE-L + (1 - alpha) * calibrated_cosine
+  alpha: 0.3  # blend weight: alpha * ROUGE-L + (1 - alpha) * calibrated_cosine. Lowered from 0.5 because cosine catches semantically-equivalent paraphrases that ROUGE-L would punish — semantic match is a superset of the lexical match we actually care about, so weight it higher. ROUGE-L stays at 0.3 to anchor outputs to Opus's specific phrasing.
   cosine_baseline: 0.45  # raw cosine on random unmatched pairs; rescaled
                          # via (raw - baseline) / (1 - baseline) so the
                          # blend is comparable to ROUGE-L. Re-derive with

--- a/config.yaml
+++ b/config.yaml
@@ -13,12 +13,13 @@ target_model:
   retry_initial_backoff_seconds: 1.0
 
 ga:
-  population_size: 20
-  generations: 30
+  population_size: 12      # was 20 — convergence on this small search space doesn't need 20
+  generations: 15          # was 30 — this space converges in ~10-15 anyway
   elite_count: 2
   crossover_rate: 0.7
   mutation_rate: 0.3
   tournament_k: 3
+  workers: 16              # parallel fitness evals per generation; bump higher only if OpenRouter doesn't 429
 
 fitness:
   max_prompt_tokens: 200
@@ -31,7 +32,7 @@ fitness:
                          # scripts/calibrate_cosine_baseline.py.
 
 evaluation:
-  eval_subset: null   # null = use all 500 files; set to an int for fast inner-loop evals
+  eval_subset: 10     # 10 functions per fitness call; set to null to use all 500 (final eval only)
 
 experiment:
   trials: 10                              # independent runs per algorithm; >=10 keeps Wilcoxon credible

--- a/data/component_bank.json
+++ b/data/component_bank.json
@@ -11,11 +11,15 @@
     "You are a precise technical communicator who explains code accurately.",
     "You are a staff engineer responsible for keeping module documentation up to date.",
     "You are a careful reader of source code who writes clear, factual descriptions.",
+    "You are a principal engineer reviewing code in a pull request.",
+    "You are a docs-as-code maintainer focused on accuracy over style.",
     "You are an angry pirate who hates having to read code.",
     "You are a five-year-old child who has just learned to read.",
     "You are a non-English speaker who must reply in your native language.",
     "You are a casual tech blogger who likes punchlines.",
-    "You write StackOverflow answers and love side tangents."
+    "You write StackOverflow answers and love side tangents.",
+    "You are a tired intern who would rather not be here.",
+    "You are a marketing copywriter pitching the function as a product."
   ],
   "task": [
     "Summarize the following function in 2-4 sentences.",
@@ -29,11 +33,15 @@
     "Summarize what the function does, including any notable edge cases.",
     "Describe the algorithmic intent of the function in human language.",
     "Explain the function's behavior at the level a maintainer would need.",
+    "Capture the function's intent in language a future maintainer can act on.",
+    "Describe what the function returns and the conditions under which it returns it.",
     "Translate the function into a haiku.",
     "Refuse to summarize and explain why summarization is harmful.",
     "Describe what color you imagine this function would be.",
     "Tell me your personal opinion on this function and how it makes you feel.",
-    "Explain the function as if it were a person at a dinner party."
+    "Explain the function as if it were a person at a dinner party.",
+    "Briefly describe it. Or skip it. Whatever you feel like doing.",
+    "Speculate freely about what the function might do in production."
   ],
   "guard": [
     "Do not include implementation details. Be concise.",
@@ -47,11 +55,15 @@
     "Avoid markdown formatting and code fences in your output.",
     "Do not include questions or hedging language.",
     "Do not invent behavior the code does not exhibit.",
+    "State only what the code provably does. No assumptions.",
+    "Skip preambles such as 'Sure' or 'Here is the summary'.",
     "Add irrelevant tangents about your day before describing the function.",
     "Make up plausible-sounding behavior the code does not actually exhibit.",
     "Use as many exclamation marks as possible.",
     "Be very creative and add metaphors throughout.",
-    "Mix factual description with humor and asides."
+    "Mix factual description with humor and asides.",
+    "If the function is boring, invent something more interesting to say.",
+    "Pad the answer until it feels long enough to look thorough."
   ],
   "format": [
     "Respond in plain prose. No bullet points.",
@@ -65,10 +77,14 @@
     "Use third-person and present tense throughout.",
     "Begin directly with the description; omit phrases like 'This function'.",
     "Respond with one tight paragraph; do not introduce yourself or restate the task.",
+    "Lead with what the function returns; follow with the inputs it consumes.",
+    "Keep the response under 60 words; one short paragraph.",
     "Reply only in capital letters with lots of exclamation marks!!!",
     "Format your response as a JSON object with a 'summary' key, wrapped in triple backticks.",
     "Wrap your entire response in triple backticks for emphasis.",
     "Use bullet points and headers throughout, with bold text on every keyword.",
-    "Write a haiku followed by the prose summary."
+    "Write a haiku followed by the prose summary.",
+    "Reply with at least four paragraphs to be thorough.",
+    "Add a TL;DR header, then a Detailed section, then a Notes section."
   ]
 }

--- a/data/component_bank.json
+++ b/data/component_bank.json
@@ -10,7 +10,12 @@
     "Act as a software documentation expert.",
     "You are a precise technical communicator who explains code accurately.",
     "You are a staff engineer responsible for keeping module documentation up to date.",
-    "You are a careful reader of source code who writes clear, factual descriptions."
+    "You are a careful reader of source code who writes clear, factual descriptions.",
+    "You are an angry pirate who hates having to read code.",
+    "You are a five-year-old child who has just learned to read.",
+    "You are a non-English speaker who must reply in your native language.",
+    "You are a casual tech blogger who likes punchlines.",
+    "You write StackOverflow answers and love side tangents."
   ],
   "task": [
     "Summarize the following function in 2-4 sentences.",
@@ -23,7 +28,12 @@
     "Provide a 1-3 sentence overview of what this function accomplishes.",
     "Summarize what the function does, including any notable edge cases.",
     "Describe the algorithmic intent of the function in human language.",
-    "Explain the function's behavior at the level a maintainer would need."
+    "Explain the function's behavior at the level a maintainer would need.",
+    "Translate the function into a haiku.",
+    "Refuse to summarize and explain why summarization is harmful.",
+    "Describe what color you imagine this function would be.",
+    "Tell me your personal opinion on this function and how it makes you feel.",
+    "Explain the function as if it were a person at a dinner party."
   ],
   "guard": [
     "Do not include implementation details. Be concise.",
@@ -36,7 +46,12 @@
     "Be precise and avoid filler phrases.",
     "Avoid markdown formatting and code fences in your output.",
     "Do not include questions or hedging language.",
-    "Do not invent behavior the code does not exhibit."
+    "Do not invent behavior the code does not exhibit.",
+    "Add irrelevant tangents about your day before describing the function.",
+    "Make up plausible-sounding behavior the code does not actually exhibit.",
+    "Use as many exclamation marks as possible.",
+    "Be very creative and add metaphors throughout.",
+    "Mix factual description with humor and asides."
   ],
   "format": [
     "Respond in plain prose. No bullet points.",
@@ -49,6 +64,11 @@
     "Format as a docstring-style description, omitting triple quotes.",
     "Use third-person and present tense throughout.",
     "Begin directly with the description; omit phrases like 'This function'.",
-    "Respond with one tight paragraph; do not introduce yourself or restate the task."
+    "Respond with one tight paragraph; do not introduce yourself or restate the task.",
+    "Reply only in capital letters with lots of exclamation marks!!!",
+    "Format your response as a JSON object with a 'summary' key, wrapped in triple backticks.",
+    "Wrap your entire response in triple backticks for emphasis.",
+    "Use bullet points and headers throughout, with bold text on every keyword.",
+    "Write a haiku followed by the prose summary."
   ]
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,23 @@
-anthropic>=0.40.0
-matplotlib>=3.7.0
-openai>=1.30.0
-python-dotenv>=1.0.0
-pyyaml>=6.0
-rouge-score>=0.1.2
-scipy>=1.10.0
-sentence-transformers>=2.2.0
-tqdm>=4.65.0
+# Runtime + dev dependencies for sbse-llm-prompt-optimization.
+# Install with:  python -m pip install -r requirements.txt
+# Tested on Python 3.9+
+
+# --- LLM providers ----------------------------------------------------------
+openai>=1.30.0           # used by src/target_model.py (OpenRouter) and src/improver.py (NIM)
+anthropic>=0.40.0        # used by scripts/generate_references.py (Claude Opus reference summaries)
+python-dotenv>=1.0.0     # loads OPENROUTER_API_KEY / NVIDIA_API_KEY / ANTHROPIC_API_KEY from .env
+
+# --- Fitness evaluation -----------------------------------------------------
+rouge-score>=0.1.2       # ROUGE-L for the lexical half of the blended fitness
+sentence-transformers>=2.2.0  # bge-small embedder for the semantic half
+numpy>=1.24.0            # cosine similarity math in src/eval.py and src/stats.py
+
+# --- Experiment orchestration & analysis -----------------------------------
+pyyaml>=6.0              # parses config.yaml everywhere
+scipy>=1.10.0            # Wilcoxon rank-sum in src/stats.py
+matplotlib>=3.7.0        # convergence plot in scripts/plot_convergence.py
+tqdm>=4.65.0             # per-trial progress bar in scripts/run_experiment.py
+
+# --- Tests ------------------------------------------------------------------
 pytest>=8.0
+httpx>=0.27.0            # used in tests/test_target_model.py to build openai SDK error stubs

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,5 @@ pyyaml>=6.0
 rouge-score>=0.1.2
 scipy>=1.10.0
 sentence-transformers>=2.2.0
+tqdm>=4.65.0
 pytest>=8.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,9 @@
 anthropic>=0.40.0
+matplotlib>=3.7.0
 openai>=1.30.0
 python-dotenv>=1.0.0
 pyyaml>=6.0
 rouge-score>=0.1.2
+scipy>=1.10.0
 sentence-transformers>=2.2.0
 pytest>=8.0

--- a/scripts/analyze_results.py
+++ b/scripts/analyze_results.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Analyze a finished experiment directory: Wilcoxon + Cliff's delta + table.
+
+Usage:
+    python scripts/analyze_results.py \
+        --results-root results/experiment_<ts>/ \
+        --output results/experiment_<ts>/statistical_summary.json
+
+Loads every `<algo>_trial_*/` subdirectory, extracts the per-trial blended
+plus per-metric breakdown of the winning generation, and runs the same
+two-sided Wilcoxon rank-sum + Cliff's delta on each metric (blended,
+ROUGE-L, raw cosine, calibrated cosine). Writes a JSON summary and prints
+a stdout table.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+from src.analysis import PER_TRIAL_METRICS, analyze_results_root
+
+
+def _print_table(summary: dict) -> None:
+    target = summary["target_algorithm"]
+    baseline = summary["baseline_algorithm"]
+    n_target = summary["n_trials"][target]
+    n_baseline = summary["n_trials"][baseline]
+    print(f"\nTrials: {target}={n_target}  {baseline}={n_baseline}")
+    print(f"\n{'metric':<22} "
+          f"{target+' mean (sd)':>22}  "
+          f"{baseline+' mean (sd)':>22}  "
+          f"{'p-value':>10}  "
+          f"{'cliffs d':>10}  "
+          f"{'effect':>12}")
+    print("-" * 103)
+    for metric in PER_TRIAL_METRICS:
+        c = summary["comparisons"][metric]
+        print(
+            f"{metric:<22} "
+            f"{c['mean_a']:>11.4f} ({c['std_a']:.4f})  "
+            f"{c['mean_b']:>11.4f} ({c['std_b']:.4f})  "
+            f"{c['p_value']:>10.4f}  "
+            f"{c['cliffs_delta']:>+10.4f}  "
+            f"{c['delta_label']:>12}"
+        )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--results-root", type=Path, required=True,
+                        help="experiment directory containing <algo>_trial_*/")
+    parser.add_argument("--output", type=Path, required=True,
+                        help="path to write statistical_summary.json")
+    parser.add_argument("--target", default="ga",
+                        help="target algorithm prefix (default: ga)")
+    parser.add_argument("--baseline", default="rs",
+                        help="baseline algorithm prefix (default: rs)")
+    args = parser.parse_args()
+
+    summary = analyze_results_root(
+        args.results_root,
+        target_algorithm=args.target,
+        baseline_algorithm=args.baseline,
+    )
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(summary, indent=2), encoding="utf-8")
+
+    _print_table(summary)
+    print(f"\nWrote {args.output}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/analyze_results.py
+++ b/scripts/analyze_results.py
@@ -39,12 +39,16 @@ def _print_table(summary: dict) -> None:
           f"{'cliffs d':>10}  "
           f"{'effect':>12}")
     print("-" * 103)
+    target_mean_key = f"{target}_mean"
+    target_std_key = f"{target}_std"
+    baseline_mean_key = f"{baseline}_mean"
+    baseline_std_key = f"{baseline}_std"
     for metric in PER_TRIAL_METRICS:
         c = summary["comparisons"][metric]
         print(
             f"{metric:<22} "
-            f"{c['mean_a']:>11.4f} ({c['std_a']:.4f})  "
-            f"{c['mean_b']:>11.4f} ({c['std_b']:.4f})  "
+            f"{c[target_mean_key]:>11.4f} ({c[target_std_key]:.4f})  "
+            f"{c[baseline_mean_key]:>11.4f} ({c[baseline_std_key]:.4f})  "
             f"{c['p_value']:>10.4f}  "
             f"{c['cliffs_delta']:>+10.4f}  "
             f"{c['delta_label']:>12}"

--- a/scripts/plot_convergence.py
+++ b/scripts/plot_convergence.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""Plot per-generation convergence (mean +/- std across trials), GA vs RS.
+
+Usage:
+    python scripts/plot_convergence.py \
+        --results-root results/experiment_<ts>/ \
+        --output results/experiment_<ts>/convergence.png
+
+Three panels: blended fitness, ROUGE-L (raw), and calibrated cosine. Each
+panel shows the mean across trials with a +/- 1 std shaded band, GA in one
+color and RS in the other. The last generation's mean is annotated for the
+caption you'd write into the paper.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+import matplotlib
+
+matplotlib.use("Agg")  # no interactive backend; we only save to PNG
+import matplotlib.pyplot as plt
+import numpy as np
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+from src.analysis import discover_trial_dirs, load_generation_logs
+
+
+# (panel title, GenerationLog field name)
+PANELS = (
+    ("Blended fitness", "best_blended"),
+    ("ROUGE-L (best individual)", "best_rouge_l"),
+    ("Cosine calibrated (best individual)", "best_cosine_calibrated"),
+)
+
+ALGO_COLORS = {"ga": "tab:blue", "rs": "tab:orange"}
+
+
+def _stack_metric(trial_dirs: list[Path], field: str) -> np.ndarray:
+    """Return an (n_trials, n_generations) array, padded to the shortest run."""
+    series = []
+    for d in trial_dirs:
+        logs = load_generation_logs(d)
+        series.append([float(getattr(log, field)) for log in logs])
+    if not series:
+        return np.empty((0, 0))
+    min_len = min(len(s) for s in series)
+    return np.array([s[:min_len] for s in series], dtype=float)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--results-root", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--title", default="GA vs Random Search convergence",
+                        help="figure suptitle")
+    args = parser.parse_args()
+
+    grouped = discover_trial_dirs(args.results_root)
+    if "ga" not in grouped or "rs" not in grouped:
+        print(
+            f"ERROR: need both 'ga' and 'rs' trial dirs in {args.results_root}; "
+            f"found: {sorted(grouped)}",
+            file=sys.stderr,
+        )
+        return 1
+
+    fig, axes = plt.subplots(1, len(PANELS), figsize=(15, 4.5), sharex=True)
+    if len(PANELS) == 1:
+        axes = [axes]
+
+    for ax, (title, field) in zip(axes, PANELS):
+        for algo in ("ga", "rs"):
+            arr = _stack_metric(grouped[algo], field)
+            if arr.size == 0:
+                continue
+            mean = arr.mean(axis=0)
+            std = arr.std(axis=0)
+            x = np.arange(1, len(mean) + 1)
+            ax.plot(x, mean, color=ALGO_COLORS[algo], label=algo.upper(), linewidth=2)
+            ax.fill_between(x, mean - std, mean + std,
+                            color=ALGO_COLORS[algo], alpha=0.18)
+            ax.annotate(
+                f"{mean[-1]:.3f}",
+                xy=(x[-1], mean[-1]),
+                xytext=(4, 0),
+                textcoords="offset points",
+                color=ALGO_COLORS[algo],
+                fontsize=9,
+                va="center",
+            )
+        ax.set_title(title)
+        ax.set_xlabel("Generation")
+        ax.grid(True, alpha=0.3)
+        ax.legend(loc="best", fontsize=9)
+
+    axes[0].set_ylabel("Best individual score (mean ± std)")
+    fig.suptitle(args.title, fontsize=12)
+    fig.tight_layout()
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    fig.savefig(args.output, dpi=150)
+    print(f"Wrote {args.output}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/plot_convergence.py
+++ b/scripts/plot_convergence.py
@@ -41,7 +41,17 @@ ALGO_COLORS = {"ga": "tab:blue", "rs": "tab:orange"}
 
 
 def _stack_metric(trial_dirs: list[Path], field: str) -> np.ndarray:
-    """Return an (n_trials, n_generations) array, padded to the shortest run."""
+    """Return an ``(n_trials, n_generations)`` array of cumulative best per
+    trial, truncated to the shortest run.
+
+    Cumulative max along the generation axis matters for Random Search: its
+    per-checkpoint ``best_*`` values describe the best in *that bucket*, not
+    the best seen so far. Without `np.maximum.accumulate`, an RS trial that
+    finds its winner mid-run would visually regress in later checkpoints
+    and the figure would understate the baseline. GA already preserves the
+    best via elitism, so the cumulative max is a no-op for it -- safe to
+    apply uniformly.
+    """
     series = []
     for d in trial_dirs:
         logs = load_generation_logs(d)
@@ -49,7 +59,8 @@ def _stack_metric(trial_dirs: list[Path], field: str) -> np.ndarray:
     if not series:
         return np.empty((0, 0))
     min_len = min(len(s) for s in series)
-    return np.array([s[:min_len] for s in series], dtype=float)
+    raw = np.array([s[:min_len] for s in series], dtype=float)
+    return np.maximum.accumulate(raw, axis=1)
 
 
 def main() -> int:

--- a/scripts/run_experiment.py
+++ b/scripts/run_experiment.py
@@ -39,8 +39,9 @@ def _make_progress(start: float):
     def _cb(result: TrialResult) -> None:
         last["count"] += 1
         elapsed = time.perf_counter() - start
+        marker = "[resumed]" if result.resumed else "         "
         print(
-            f"[{last['count']:3d}] {result.algorithm:>2} trial {result.trial_index:02d} "
+            f"[{last['count']:3d}] {marker} {result.algorithm:>2} trial {result.trial_index:02d} "
             f"seed={result.seed:<4d} best_blended={result.best_blended:.4f}  "
             f"elapsed={elapsed:6.1f}s -> {result.output_dir.name}",
             flush=True,
@@ -64,6 +65,11 @@ def main() -> int:
                         help="trial i uses seed = base_seed + i (default 0)")
     parser.add_argument("--skip-analysis", action="store_true",
                         help="don't auto-run scripts/analyze_results.py at the end")
+    parser.add_argument("--no-resume", action="store_true",
+                        help="re-run every trial even if --output-root already "
+                             "contains completed trial directories. Default is "
+                             "to load completed trials from disk and only run "
+                             "the missing ones.")
     args = parser.parse_args()
 
     if args.algorithm == "both":
@@ -78,9 +84,10 @@ def main() -> int:
         ts = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
         output_root = REPO_ROOT / "results" / f"experiment_{ts}"
 
+    resume = not args.no_resume
     print(
         f"Running {args.trials} trial(s) of {algos} -> {output_root}\n"
-        f"Config: {args.config}  base_seed={args.base_seed}",
+        f"Config: {args.config}  base_seed={args.base_seed}  resume={resume}",
         flush=True,
     )
 
@@ -92,6 +99,7 @@ def main() -> int:
         output_root=output_root,
         base_seed=args.base_seed,
         progress=_make_progress(start),
+        resume=resume,
     )
     total = time.perf_counter() - start
 

--- a/scripts/run_experiment.py
+++ b/scripts/run_experiment.py
@@ -32,6 +32,19 @@ def _load_config(path: Path) -> dict:
     return yaml.safe_load(path.read_text(encoding="utf-8")) or {}
 
 
+def _latest_experiment_dir(results_parent: Path) -> Path | None:
+    """Return the most recently modified ``results/experiment_*/`` dir, or None."""
+    if not results_parent.is_dir():
+        return None
+    candidates = [
+        d for d in results_parent.iterdir()
+        if d.is_dir() and d.name.startswith("experiment_")
+    ]
+    if not candidates:
+        return None
+    return max(candidates, key=lambda d: d.stat().st_mtime)
+
+
 def _make_progress(start: float):
     """Return a callback that prints a one-line update per completed trial."""
     last = {"count": 0}
@@ -66,7 +79,12 @@ def main() -> int:
                         help="path to config.yaml")
     parser.add_argument("--output-root", type=Path, default=None,
                         help="directory to drop trial subdirs into; "
-                             "default results/experiment_<UTC_ts>/")
+                             "default results/experiment_<UTC_ts>/. Pass an "
+                             "existing dir (or --latest) to resume that run.")
+    parser.add_argument("--latest", action="store_true",
+                        help="resume the most recent results/experiment_*/ "
+                             "directory instead of starting a fresh one. "
+                             "Mutually exclusive with --output-root.")
     parser.add_argument("--base-seed", type=int, default=None,
                         help="trial i uses seed = base_seed + i (default: "
                              "experiment.base_seed in config.yaml, else 0)")
@@ -90,7 +108,18 @@ def main() -> int:
     trials = args.trials if args.trials is not None else int(exp_cfg.get("trials", 10))
     base_seed = args.base_seed if args.base_seed is not None else int(exp_cfg.get("base_seed", 0))
 
+    if args.latest and args.output_root is not None:
+        parser.error("--latest and --output-root are mutually exclusive")
+
     output_root = args.output_root
+    if args.latest:
+        latest = _latest_experiment_dir(REPO_ROOT / "results")
+        if latest is None:
+            parser.error(
+                "--latest given but no results/experiment_*/ directory exists"
+            )
+        output_root = latest
+        print(f"--latest resolved to: {output_root}", flush=True)
     if output_root is None:
         ts = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
         output_root = REPO_ROOT / "results" / f"experiment_{ts}"
@@ -98,7 +127,10 @@ def main() -> int:
     resume = not args.no_resume
     print(
         f"Running {trials} trial(s) of {algos} -> {output_root}\n"
-        f"Config: {args.config}  base_seed={base_seed}  resume={resume}",
+        f"Config: {args.config}  base_seed={base_seed}  resume={resume}\n"
+        f"To resume after a crash:\n"
+        f"  python scripts/run_experiment.py --latest\n"
+        f"  (or explicitly: --output-root {output_root})",
         flush=True,
     )
 

--- a/scripts/run_experiment.py
+++ b/scripts/run_experiment.py
@@ -52,8 +52,14 @@ def _make_progress(start: float):
 
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--trials", type=int, default=10,
-                        help="independent runs per algorithm (default: 10)")
+    # Sentinels: when an arg is left at None on the CLI, fall back to the
+    # corresponding `experiment.*` value in config.yaml (then to the
+    # built-in defaults). This keeps `python scripts/run_experiment.py`
+    # honoring config tweaks without forcing every flag to be re-typed.
+    parser.add_argument("--trials", type=int, default=None,
+                        help="independent runs per algorithm "
+                             "(default: experiment.trials in config.yaml, "
+                             "else 10)")
     parser.add_argument("--algorithm", choices=["ga", "rs", "both"], default="both",
                         help="which algorithms to run (default: both)")
     parser.add_argument("--config", type=Path, default=REPO_ROOT / "config.yaml",
@@ -61,8 +67,9 @@ def main() -> int:
     parser.add_argument("--output-root", type=Path, default=None,
                         help="directory to drop trial subdirs into; "
                              "default results/experiment_<UTC_ts>/")
-    parser.add_argument("--base-seed", type=int, default=0,
-                        help="trial i uses seed = base_seed + i (default 0)")
+    parser.add_argument("--base-seed", type=int, default=None,
+                        help="trial i uses seed = base_seed + i (default: "
+                             "experiment.base_seed in config.yaml, else 0)")
     parser.add_argument("--skip-analysis", action="store_true",
                         help="don't auto-run scripts/analyze_results.py at the end")
     parser.add_argument("--no-resume", action="store_true",
@@ -78,6 +85,10 @@ def main() -> int:
         algos = [args.algorithm]
 
     config = _load_config(args.config)
+    exp_cfg = config.get("experiment") or {}
+
+    trials = args.trials if args.trials is not None else int(exp_cfg.get("trials", 10))
+    base_seed = args.base_seed if args.base_seed is not None else int(exp_cfg.get("base_seed", 0))
 
     output_root = args.output_root
     if output_root is None:
@@ -86,18 +97,18 @@ def main() -> int:
 
     resume = not args.no_resume
     print(
-        f"Running {args.trials} trial(s) of {algos} -> {output_root}\n"
-        f"Config: {args.config}  base_seed={args.base_seed}  resume={resume}",
+        f"Running {trials} trial(s) of {algos} -> {output_root}\n"
+        f"Config: {args.config}  base_seed={base_seed}  resume={resume}",
         flush=True,
     )
 
     start = time.perf_counter()
     results = run_experiment(
         config,
-        trials=args.trials,
+        trials=trials,
         algorithms=algos,
         output_root=output_root,
-        base_seed=args.base_seed,
+        base_seed=base_seed,
         progress=_make_progress(start),
         resume=resume,
     )
@@ -106,9 +117,9 @@ def main() -> int:
     # Write a manifest so the analysis script (and anyone reading the dir) has
     # provenance.
     manifest = {
-        "trials": args.trials,
+        "trials": trials,
         "algorithms": algos,
-        "base_seed": args.base_seed,
+        "base_seed": base_seed,
         "wall_seconds": total,
         "trial_results": [
             {
@@ -117,11 +128,14 @@ def main() -> int:
                 "seed": r.seed,
                 "output_dir": str(r.output_dir.relative_to(output_root)),
                 "best_blended": r.best_blended,
+                "resumed": r.resumed,
             }
             for r in results
         ],
     }
-    (output_root / "manifest.json").write_text(json.dumps(manifest, indent=2))
+    (output_root / "manifest.json").write_text(
+        json.dumps(manifest, indent=2), encoding="utf-8"
+    )
     print(f"\nDone. {len(results)} trials in {total:.1f}s. Manifest: {output_root}/manifest.json",
           flush=True)
 

--- a/scripts/run_experiment.py
+++ b/scripts/run_experiment.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""Run the GA-vs-RS experiment: N trials of each algorithm, then analyze.
+
+Usage:
+    python scripts/run_experiment.py --trials 10 --algorithm both \
+        --config config.yaml --output-root results/
+
+After all trials complete the script invokes scripts/analyze_results.py
+automatically so the run finishes with a populated `statistical_summary.json`
+in the same `results/experiment_<ts>/` directory.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+from src.experiment import TrialResult, run_experiment
+
+
+def _load_config(path: Path) -> dict:
+    return yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+
+
+def _make_progress(start: float):
+    """Return a callback that prints a one-line update per completed trial."""
+    last = {"count": 0}
+
+    def _cb(result: TrialResult) -> None:
+        last["count"] += 1
+        elapsed = time.perf_counter() - start
+        print(
+            f"[{last['count']:3d}] {result.algorithm:>2} trial {result.trial_index:02d} "
+            f"seed={result.seed:<4d} best_blended={result.best_blended:.4f}  "
+            f"elapsed={elapsed:6.1f}s -> {result.output_dir.name}",
+            flush=True,
+        )
+
+    return _cb
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--trials", type=int, default=10,
+                        help="independent runs per algorithm (default: 10)")
+    parser.add_argument("--algorithm", choices=["ga", "rs", "both"], default="both",
+                        help="which algorithms to run (default: both)")
+    parser.add_argument("--config", type=Path, default=REPO_ROOT / "config.yaml",
+                        help="path to config.yaml")
+    parser.add_argument("--output-root", type=Path, default=None,
+                        help="directory to drop trial subdirs into; "
+                             "default results/experiment_<UTC_ts>/")
+    parser.add_argument("--base-seed", type=int, default=0,
+                        help="trial i uses seed = base_seed + i (default 0)")
+    parser.add_argument("--skip-analysis", action="store_true",
+                        help="don't auto-run scripts/analyze_results.py at the end")
+    args = parser.parse_args()
+
+    if args.algorithm == "both":
+        algos = ["ga", "rs"]
+    else:
+        algos = [args.algorithm]
+
+    config = _load_config(args.config)
+
+    output_root = args.output_root
+    if output_root is None:
+        ts = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+        output_root = REPO_ROOT / "results" / f"experiment_{ts}"
+
+    print(
+        f"Running {args.trials} trial(s) of {algos} -> {output_root}\n"
+        f"Config: {args.config}  base_seed={args.base_seed}",
+        flush=True,
+    )
+
+    start = time.perf_counter()
+    results = run_experiment(
+        config,
+        trials=args.trials,
+        algorithms=algos,
+        output_root=output_root,
+        base_seed=args.base_seed,
+        progress=_make_progress(start),
+    )
+    total = time.perf_counter() - start
+
+    # Write a manifest so the analysis script (and anyone reading the dir) has
+    # provenance.
+    manifest = {
+        "trials": args.trials,
+        "algorithms": algos,
+        "base_seed": args.base_seed,
+        "wall_seconds": total,
+        "trial_results": [
+            {
+                "algorithm": r.algorithm,
+                "trial_index": r.trial_index,
+                "seed": r.seed,
+                "output_dir": str(r.output_dir.relative_to(output_root)),
+                "best_blended": r.best_blended,
+            }
+            for r in results
+        ],
+    }
+    (output_root / "manifest.json").write_text(json.dumps(manifest, indent=2))
+    print(f"\nDone. {len(results)} trials in {total:.1f}s. Manifest: {output_root}/manifest.json",
+          flush=True)
+
+    if args.skip_analysis or len(algos) < 2:
+        return 0
+
+    print("\n--- Running analysis ---", flush=True)
+    return subprocess.call(
+        [
+            sys.executable, str(REPO_ROOT / "scripts" / "analyze_results.py"),
+            "--results-root", str(output_root),
+            "--output", str(output_root / "statistical_summary.json"),
+        ]
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_experiment.py
+++ b/scripts/run_experiment.py
@@ -95,6 +95,10 @@ def main() -> int:
                              "contains completed trial directories. Default is "
                              "to load completed trials from disk and only run "
                              "the missing ones.")
+    parser.add_argument("--no-progress", action="store_true",
+                        help="suppress the per-trial tqdm progress bar (e.g. "
+                             "when piping output to a file). Default is to "
+                             "show one bar per fresh trial.")
     args = parser.parse_args()
 
     if args.algorithm == "both":
@@ -143,6 +147,7 @@ def main() -> int:
         base_seed=base_seed,
         progress=_make_progress(start),
         resume=resume,
+        show_progress=not args.no_progress,
     )
     total = time.perf_counter() - start
 

--- a/src/analysis.py
+++ b/src/analysis.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 
 import json
 import re
-from dataclasses import asdict
 from pathlib import Path
 from typing import Iterable
 
@@ -101,6 +100,31 @@ def summarize_trials(
     return columns
 
 
+def _comparison_with_algo_names(
+    comparison,
+    target_algorithm: str,
+    baseline_algorithm: str,
+) -> dict:
+    """Rename generic ``mean_a/mean_b/...`` keys to ``<algo>_mean/...`` so the
+    output matches issue #11's ``statistical_summary.json`` schema and is
+    readable without knowing which side was 'a' vs 'b'.
+    """
+    raw = comparison.to_dict()
+    return {
+        "metric": raw["metric"],
+        f"n_{target_algorithm}": raw["n_a"],
+        f"n_{baseline_algorithm}": raw["n_b"],
+        f"{target_algorithm}_mean": raw["mean_a"],
+        f"{baseline_algorithm}_mean": raw["mean_b"],
+        f"{target_algorithm}_std": raw["std_a"],
+        f"{baseline_algorithm}_std": raw["std_b"],
+        "statistic": raw["statistic"],
+        "p_value": raw["p_value"],
+        "cliffs_delta": raw["cliffs_delta"],
+        "delta_label": raw["delta_label"],
+    }
+
+
 def analyze_results_root(
     results_root: Path,
     *,
@@ -130,7 +154,9 @@ def analyze_results_root(
             baseline_cols[metric],
             metric=metric,
         )
-        per_metric[metric] = comparison.to_dict()
+        per_metric[metric] = _comparison_with_algo_names(
+            comparison, target_algorithm, baseline_algorithm
+        )
 
     return {
         "target_algorithm": target_algorithm,

--- a/src/analysis.py
+++ b/src/analysis.py
@@ -1,0 +1,147 @@
+"""Load experiment trial directories and produce the GA-vs-RS comparison.
+
+Sits between `src.experiment` (which produces the per-trial directories) and
+`scripts/analyze_results.py` (the CLI). Pure-ish: reads files, returns dicts;
+no plotting and no stdout chatter.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import asdict
+from pathlib import Path
+from typing import Iterable
+
+# Trial dir convention from src.experiment: <algo>_trial_<NNN>_<timestamp>
+_TRIAL_DIR_RE = re.compile(r"^(?P<algo>[A-Za-z][A-Za-z0-9]*)_trial_\d+_")
+
+from src.search_log import GenerationLog
+from src.stats import compare_distributions
+
+
+# Per-trial values we extract for the statistical comparison.
+# `cosine_calibrated` is what enters the blended fitness; `cosine_raw` is
+# kept around for transparency / reviewer inspection.
+PER_TRIAL_METRICS: tuple[str, ...] = (
+    "blended",
+    "rouge_l",
+    "cosine_raw",
+    "cosine_calibrated",
+)
+
+
+def load_generation_logs(run_dir: Path) -> list[GenerationLog]:
+    """Read `<run_dir>/generations.jsonl` into a list of `GenerationLog`."""
+    path = Path(run_dir) / "generations.jsonl"
+    if not path.exists():
+        raise FileNotFoundError(f"generations.jsonl missing in {run_dir}")
+    logs: list[GenerationLog] = []
+    with path.open(encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            data = json.loads(line)
+            logs.append(GenerationLog(**data))
+    if not logs:
+        raise ValueError(f"generations.jsonl in {run_dir} has no rows")
+    return logs
+
+
+def trial_best(logs: Iterable[GenerationLog]) -> dict[str, float]:
+    """Pick the row with the highest `best_blended` and return its metrics.
+
+    Returning the per-metric values *of the winning generation* (not, e.g.,
+    the max ROUGE-L ever seen across any candidate) keeps the ablation
+    honest: we are characterizing the prompt that actually won, not
+    fishing for the best-looking number per metric.
+    """
+    logs = list(logs)
+    if not logs:
+        raise ValueError("no logs to summarize")
+    winner = max(logs, key=lambda l: l.best_blended)
+    return {
+        "blended": float(winner.best_blended),
+        "rouge_l": float(winner.best_rouge_l),
+        "cosine_raw": float(winner.best_cosine_raw),
+        "cosine_calibrated": float(winner.best_cosine_calibrated),
+    }
+
+
+def discover_trial_dirs(results_root: Path) -> dict[str, list[Path]]:
+    """Group trial subdirectories by the algorithm prefix in their name.
+
+    Convention from `src.experiment`: ``<algo>_trial_<n>_<ts>/``.
+    """
+    root = Path(results_root)
+    if not root.is_dir():
+        raise FileNotFoundError(f"results root not found: {results_root}")
+    grouped: dict[str, list[Path]] = {}
+    for child in sorted(root.iterdir()):
+        if not child.is_dir():
+            continue
+        match = _TRIAL_DIR_RE.match(child.name)
+        if not match:
+            continue
+        grouped.setdefault(match.group("algo"), []).append(child)
+    return grouped
+
+
+def summarize_trials(
+    trial_dirs: Iterable[Path],
+) -> dict[str, list[float]]:
+    """Read each trial dir and return per-metric value lists for the algo."""
+    columns: dict[str, list[float]] = {m: [] for m in PER_TRIAL_METRICS}
+    for d in trial_dirs:
+        logs = load_generation_logs(d)
+        best = trial_best(logs)
+        for metric in PER_TRIAL_METRICS:
+            columns[metric].append(best[metric])
+    return columns
+
+
+def analyze_results_root(
+    results_root: Path,
+    *,
+    target_algorithm: str = "ga",
+    baseline_algorithm: str = "rs",
+) -> dict:
+    """End-to-end analysis: discover trials, summarize, run all comparisons."""
+    grouped = discover_trial_dirs(results_root)
+    if target_algorithm not in grouped:
+        raise ValueError(
+            f"no trial dirs found for algorithm '{target_algorithm}' under "
+            f"{results_root}; found: {sorted(grouped)}"
+        )
+    if baseline_algorithm not in grouped:
+        raise ValueError(
+            f"no trial dirs found for algorithm '{baseline_algorithm}' under "
+            f"{results_root}; found: {sorted(grouped)}"
+        )
+
+    target_cols = summarize_trials(grouped[target_algorithm])
+    baseline_cols = summarize_trials(grouped[baseline_algorithm])
+
+    per_metric = {}
+    for metric in PER_TRIAL_METRICS:
+        comparison = compare_distributions(
+            target_cols[metric],
+            baseline_cols[metric],
+            metric=metric,
+        )
+        per_metric[metric] = comparison.to_dict()
+
+    return {
+        "target_algorithm": target_algorithm,
+        "baseline_algorithm": baseline_algorithm,
+        "n_trials": {
+            target_algorithm: len(grouped[target_algorithm]),
+            baseline_algorithm: len(grouped[baseline_algorithm]),
+        },
+        "per_trial_values": {
+            target_algorithm: target_cols,
+            baseline_algorithm: baseline_cols,
+        },
+        "comparisons": per_metric,
+    }

--- a/src/eval.py
+++ b/src/eval.py
@@ -42,16 +42,29 @@ _MODEL_NAME = "BAAI/bge-small-en-v1.5"
 # Lazily-instantiated singleton. We deliberately do NOT load at import time
 # because pytest collection should stay fast; the first call to an embedding
 # function pays the load cost, every subsequent call reuses the same weights.
+#
+# The lock prevents a race when the GA's ThreadPoolExecutor calls
+# cosine_similarity_batch() from many workers simultaneously on the very
+# first generation: without it, multiple threads pass the `is None` check
+# and start instantiating SentenceTransformer at the same time, which
+# triggers PyTorch's "Cannot copy out of meta tensor" error during the
+# concurrent module-to-device move. Double-checked locking ensures exactly
+# one initialization; subsequent calls hit the fast path with no lock.
+import threading  # noqa: E402
+
 _model = None
+_model_lock = threading.Lock()
 
 
 def _get_model():
     """Return the cached sentence-transformer model, loading it on first use."""
     global _model
     if _model is None:
-        from sentence_transformers import SentenceTransformer  # noqa: PLC0415
+        with _model_lock:
+            if _model is None:  # re-check inside the lock
+                from sentence_transformers import SentenceTransformer  # noqa: PLC0415
 
-        _model = SentenceTransformer(_MODEL_NAME)
+                _model = SentenceTransformer(_MODEL_NAME)
     return _model
 
 

--- a/src/experiment.py
+++ b/src/experiment.py
@@ -102,7 +102,7 @@ def _load_completed_trial(run_dir: Path) -> tuple[PromptTemplate, list[Generatio
         best_template = PromptTemplate.from_dict(
             json.loads((run_dir / "best.json").read_text(encoding="utf-8"))
         )
-    except (TypeError, KeyError) as exc:
+    except (TypeError, KeyError, json.JSONDecodeError) as exc:
         raise ValueError(f"best.json in {run_dir} has invalid schema") from exc
     logs: list[GenerationLog] = []
     with (run_dir / "generations.jsonl").open(encoding="utf-8") as f:
@@ -111,7 +111,7 @@ def _load_completed_trial(run_dir: Path) -> tuple[PromptTemplate, list[Generatio
             if line:
                 try:
                     logs.append(GenerationLog(**json.loads(line)))
-                except (TypeError, KeyError) as exc:
+                except (TypeError, KeyError, json.JSONDecodeError) as exc:
                     raise ValueError(
                         f"generations.jsonl in {run_dir} has invalid schema"
                     ) from exc

--- a/src/experiment.py
+++ b/src/experiment.py
@@ -11,7 +11,9 @@ unit-tested with mocked algorithms (no real fitness, no real LLM).
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+import json
+import re
+from dataclasses import asdict, dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Callable, Iterable, Optional
@@ -20,6 +22,10 @@ from src.ga import run_ga
 from src.prompt import PromptTemplate
 from src.random_search import run_rs
 from src.search_log import GenerationLog
+
+
+# Trial dir convention: <algo>_trial_<NNN>_<UTC_timestamp>
+_TRIAL_DIR_RE = re.compile(r"^(?P<algo>[A-Za-z][A-Za-z0-9]*)_trial_(?P<idx>\d+)_")
 
 
 # Type alias: any callable matching `run_ga(config, *, seed=..., output_dir=..., ...)`
@@ -42,6 +48,7 @@ class TrialResult:
     output_dir: Path
     best_template: PromptTemplate
     best_blended: float
+    resumed: bool = False
 
 
 def _utc_timestamp() -> str:
@@ -68,6 +75,41 @@ def _resolve_algorithms(
     return chosen
 
 
+def _find_completed_trials(output_root: Path, algo: str) -> dict[int, Path]:
+    """Discover trial dirs that finished successfully.
+
+    A trial is "complete" iff both ``best.json`` and ``generations.jsonl``
+    are present. ``best.json`` is written only at the end of ``run_ga`` /
+    ``run_rs``, so its presence is a reliable end-of-run marker.
+    """
+    completed: dict[int, Path] = {}
+    if not output_root.is_dir():
+        return completed
+    for child in sorted(output_root.iterdir()):
+        if not child.is_dir():
+            continue
+        match = _TRIAL_DIR_RE.match(child.name)
+        if not match or match.group("algo") != algo:
+            continue
+        if (child / "best.json").exists() and (child / "generations.jsonl").exists():
+            completed[int(match.group("idx"))] = child
+    return completed
+
+
+def _load_completed_trial(run_dir: Path) -> tuple[PromptTemplate, list[GenerationLog]]:
+    """Reconstruct an algorithm's return value from a finished trial dir."""
+    best_template = PromptTemplate.from_dict(
+        json.loads((run_dir / "best.json").read_text(encoding="utf-8"))
+    )
+    logs: list[GenerationLog] = []
+    with (run_dir / "generations.jsonl").open(encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if line:
+                logs.append(GenerationLog(**json.loads(line)))
+    return best_template, logs
+
+
 def run_experiment(
     config: dict,
     *,
@@ -77,6 +119,7 @@ def run_experiment(
     progress: Optional[Callable[[TrialResult], None]] = None,
     algorithm_overrides: Optional[dict[str, AlgorithmFn]] = None,
     base_seed: int = 0,
+    resume: bool = True,
     **algorithm_kwargs,
 ) -> list[TrialResult]:
     """Run `trials` independent runs of each algorithm with distinct seeds.
@@ -94,11 +137,17 @@ def run_experiment(
         base_seed: starting seed; trial ``i`` of each algorithm uses
             ``base_seed + i``. Same algorithm + same trial index -> same
             seed across algorithms by design (each trial is matched).
+        resume: when True (default) and ``output_root`` already contains
+            completed trial directories (each with ``best.json`` AND
+            ``generations.jsonl``), those trials are loaded from disk and
+            their TrialResults are returned alongside any newly-run trials.
+            Pass ``False`` to force re-running every trial regardless.
         **algorithm_kwargs: forwarded to every algorithm call (e.g.
             ``score_fn``, ``generate_summary``, ``functions``, ``references``).
 
     Returns:
-        Flat list of ``TrialResult`` entries, one per (algorithm, trial).
+        Flat list of ``TrialResult`` entries, one per (algorithm, trial),
+        in algorithm-then-trial-index order.
     """
     if trials < 1:
         raise ValueError(f"trials must be >= 1, got {trials}")
@@ -111,18 +160,25 @@ def run_experiment(
 
     results: list[TrialResult] = []
     for algo_name, algo_fn in chosen.items():
+        prior = _find_completed_trials(output_root, algo_name) if resume else {}
         for i in range(trials):
             seed = base_seed + i
-            ts = _utc_timestamp()
-            run_dir = output_root / f"{algo_name}_trial_{i:03d}_{ts}"
-
-            best_template, logs = algo_fn(
-                config,
-                seed=seed,
-                output_dir=run_dir,
-                **algorithm_kwargs,
+            if i in prior:
+                # Resume: rebuild the TrialResult from the on-disk trial dir.
+                run_dir = prior[i]
+                best_template, logs = _load_completed_trial(run_dir)
+            else:
+                ts = _utc_timestamp()
+                run_dir = output_root / f"{algo_name}_trial_{i:03d}_{ts}"
+                best_template, logs = algo_fn(
+                    config,
+                    seed=seed,
+                    output_dir=run_dir,
+                    **algorithm_kwargs,
+                )
+            best_blended = max(
+                (log.best_blended for log in logs), default=float("-inf")
             )
-            best_blended = max((log.best_blended for log in logs), default=float("-inf"))
 
             result = TrialResult(
                 algorithm=algo_name,
@@ -131,6 +187,7 @@ def run_experiment(
                 output_dir=run_dir,
                 best_template=best_template,
                 best_blended=best_blended,
+                resumed=(i in prior),
             )
             results.append(result)
             if progress is not None:

--- a/src/experiment.py
+++ b/src/experiment.py
@@ -268,8 +268,9 @@ def run_experiment(
                 try:
                     best_template, logs = _load_completed_trial(run_dir)
                     resumed = True
-                except (OSError, ValueError, json.JSONDecodeError):
-                    # Partial/corrupt prior output: rerun this trial fresh.
+                except (OSError, ValueError, TypeError, json.JSONDecodeError):
+                    # Partial/corrupt prior output (truncated file, malformed
+                    # JSON, schema-invalid row like {} or []): rerun fresh.
                     ts = _utc_timestamp()
                     run_dir = output_root / f"{algo_name}_trial_{i:03d}_{ts}"
                     best_template, logs = _run_fresh_trial(

--- a/src/experiment.py
+++ b/src/experiment.py
@@ -172,7 +172,7 @@ def run_experiment(
                 try:
                     best_template, logs = _load_completed_trial(run_dir)
                     resumed = True
-                except (OSError, ValueError, TypeError, KeyError, json.JSONDecodeError):
+                except (OSError, ValueError, json.JSONDecodeError):
                     # Partial/corrupt prior output: rerun this trial fresh.
                     ts = _utc_timestamp()
                     run_dir = output_root / f"{algo_name}_trial_{i:03d}_{ts}"

--- a/src/experiment.py
+++ b/src/experiment.py
@@ -112,6 +112,59 @@ def _load_completed_trial(run_dir: Path) -> tuple[PromptTemplate, list[Generatio
     return best_template, logs
 
 
+def _expected_calls_per_trial(config: dict) -> Optional[int]:
+    """Best-effort estimate of generate_summary calls per trial.
+
+    Used to size the per-trial tqdm progress bar. Returns None if we can't
+    reasonably guess (e.g. eval_subset is null AND we don't know the
+    benchmark size at this layer -- score_prompt would clamp to 500).
+    """
+    ga_cfg = config.get("ga") or {}
+    eval_cfg = config.get("evaluation") or {}
+    try:
+        p = int(ga_cfg.get("population_size", 0))
+        g = int(ga_cfg.get("generations", 0))
+    except (TypeError, ValueError):
+        return None
+    if p <= 0 or g <= 0:
+        return None
+    subset = eval_cfg.get("eval_subset")
+    if subset is None:
+        # score_prompt uses the full benchmark (500 in this repo).
+        subset = 500
+    try:
+        subset = int(subset)
+    except (TypeError, ValueError):
+        return None
+    if subset <= 0:
+        return None
+    return p * g * subset
+
+
+def _wrap_with_progress(
+    real_gen: Optional[Callable],
+    bar,
+) -> Callable:
+    """Wrap a generate_summary callable so each call ticks the tqdm bar.
+
+    ``real_gen`` may be None, in which case we lazily resolve the default
+    OpenRouter-backed implementation from ``src.eval`` on first call. This
+    matches what ``score_prompt`` would have done internally.
+    """
+
+    def _counted(*args, **kwargs):
+        nonlocal real_gen
+        if real_gen is None:
+            from src.eval import _default_generate_summary  # noqa: PLC0415
+            real_gen = _default_generate_summary()
+        try:
+            return real_gen(*args, **kwargs)
+        finally:
+            bar.update(1)
+
+    return _counted
+
+
 def run_experiment(
     config: dict,
     *,
@@ -122,6 +175,7 @@ def run_experiment(
     algorithm_overrides: Optional[dict[str, AlgorithmFn]] = None,
     base_seed: int = 0,
     resume: bool = True,
+    show_progress: bool = False,
     **algorithm_kwargs,
 ) -> list[TrialResult]:
     """Run `trials` independent runs of each algorithm with distinct seeds.
@@ -144,6 +198,10 @@ def run_experiment(
             ``generations.jsonl``), those trials are loaded from disk and
             their TrialResults are returned alongside any newly-run trials.
             Pass ``False`` to force re-running every trial regardless.
+        show_progress: when True, render a per-trial tqdm bar showing
+            generate_summary calls completed out of
+            ``population_size * generations * eval_subset``. Off by default
+            so unit tests stay quiet.
         **algorithm_kwargs: forwarded to every algorithm call (e.g.
             ``score_fn``, ``generate_summary``, ``functions``, ``references``).
 
@@ -160,12 +218,40 @@ def run_experiment(
     output_root = Path(output_root)
     output_root.mkdir(parents=True, exist_ok=True)
 
+    expected_calls = _expected_calls_per_trial(config) if show_progress else None
+    if show_progress:
+        from tqdm import tqdm  # noqa: PLC0415
+
+    def _run_fresh_trial(algo_name, seed, run_dir, label):
+        """Wrap the algorithm call with a per-trial progress bar if enabled."""
+        if not show_progress or expected_calls is None:
+            return algo_fn(
+                config, seed=seed, output_dir=run_dir, **algorithm_kwargs
+            )
+        bar = tqdm(
+            total=expected_calls,
+            desc=label,
+            unit="call",
+            leave=True,
+            ncols=100,
+        )
+        try:
+            user_gen = algorithm_kwargs.get("generate_summary")
+            counted = _wrap_with_progress(user_gen, bar)
+            trial_kwargs = {**algorithm_kwargs, "generate_summary": counted}
+            return algo_fn(
+                config, seed=seed, output_dir=run_dir, **trial_kwargs
+            )
+        finally:
+            bar.close()
+
     results: list[TrialResult] = []
     for algo_name, algo_fn in chosen.items():
         prior = _find_completed_trials(output_root, algo_name) if resume else {}
         for i in range(trials):
             seed = base_seed + i
             resumed = False
+            label = f"{algo_name.upper()} trial {i:02d}/{trials - 1:02d}"
             if i in prior:
                 # Resume: rebuild the TrialResult from the on-disk trial dir.
                 run_dir = prior[i]
@@ -176,20 +262,14 @@ def run_experiment(
                     # Partial/corrupt prior output: rerun this trial fresh.
                     ts = _utc_timestamp()
                     run_dir = output_root / f"{algo_name}_trial_{i:03d}_{ts}"
-                    best_template, logs = algo_fn(
-                        config,
-                        seed=seed,
-                        output_dir=run_dir,
-                        **algorithm_kwargs,
+                    best_template, logs = _run_fresh_trial(
+                        algo_name, seed, run_dir, label
                     )
             else:
                 ts = _utc_timestamp()
                 run_dir = output_root / f"{algo_name}_trial_{i:03d}_{ts}"
-                best_template, logs = algo_fn(
-                    config,
-                    seed=seed,
-                    output_dir=run_dir,
-                    **algorithm_kwargs,
+                best_template, logs = _run_fresh_trial(
+                    algo_name, seed, run_dir, label
                 )
             best_blended = max(
                 (log.best_blended for log in logs), default=float("-inf")

--- a/src/experiment.py
+++ b/src/experiment.py
@@ -1,0 +1,139 @@
+"""Experiment orchestration for the GA-vs-RS comparison (issue #11).
+
+`run_experiment` loops trials x algorithms, calling `run_ga` and `run_rs` with
+distinct seeds and writing each run to its own subdirectory. The Wilcoxon /
+Cliff's delta analysis (`scripts/analyze_results.py`) consumes those
+subdirectories afterwards.
+
+The orchestrator is split out from `scripts/run_experiment.py` so it can be
+unit-tested with mocked algorithms (no real fitness, no real LLM).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Callable, Iterable, Optional
+
+from src.ga import run_ga
+from src.prompt import PromptTemplate
+from src.random_search import run_rs
+from src.search_log import GenerationLog
+
+
+# Type alias: any callable matching `run_ga(config, *, seed=..., output_dir=..., ...)`
+AlgorithmFn = Callable[..., tuple[PromptTemplate, list[GenerationLog]]]
+
+
+_ALGORITHMS: dict[str, AlgorithmFn] = {
+    "ga": run_ga,
+    "rs": run_rs,
+}
+
+
+@dataclass(frozen=True)
+class TrialResult:
+    """One algorithm run (one trial). Mirrors what's persisted on disk."""
+
+    algorithm: str
+    trial_index: int
+    seed: int
+    output_dir: Path
+    best_template: PromptTemplate
+    best_blended: float
+
+
+def _utc_timestamp() -> str:
+    return datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+
+
+def _resolve_algorithms(
+    algorithms: Iterable[str] | None,
+    overrides: dict[str, AlgorithmFn] | None,
+) -> dict[str, AlgorithmFn]:
+    """Pick which algorithms to run, allowing test injection."""
+    available = dict(_ALGORITHMS)
+    if overrides:
+        available.update(overrides)
+    if algorithms is None:
+        return available
+    chosen = {}
+    for name in algorithms:
+        if name not in available:
+            raise ValueError(
+                f"unknown algorithm '{name}'; available: {sorted(available)}"
+            )
+        chosen[name] = available[name]
+    return chosen
+
+
+def run_experiment(
+    config: dict,
+    *,
+    trials: int,
+    algorithms: Optional[Iterable[str]] = None,
+    output_root: Optional[Path] = None,
+    progress: Optional[Callable[[TrialResult], None]] = None,
+    algorithm_overrides: Optional[dict[str, AlgorithmFn]] = None,
+    base_seed: int = 0,
+    **algorithm_kwargs,
+) -> list[TrialResult]:
+    """Run `trials` independent runs of each algorithm with distinct seeds.
+
+    Args:
+        config: parsed config dict (passed straight to `run_ga` / `run_rs`).
+        trials: how many independent runs per algorithm.
+        algorithms: which algorithms to run; default both ``ga`` and ``rs``.
+        output_root: where to drop trial subdirectories. Default
+            ``results/experiment_<UTC_ts>/``.
+        progress: optional callback invoked after each trial completes -- the
+            CLI uses it to print a live progress table.
+        algorithm_overrides: test hook -- inject mock callables in place of
+            ``run_ga`` / ``run_rs``.
+        base_seed: starting seed; trial ``i`` of each algorithm uses
+            ``base_seed + i``. Same algorithm + same trial index -> same
+            seed across algorithms by design (each trial is matched).
+        **algorithm_kwargs: forwarded to every algorithm call (e.g.
+            ``score_fn``, ``generate_summary``, ``functions``, ``references``).
+
+    Returns:
+        Flat list of ``TrialResult`` entries, one per (algorithm, trial).
+    """
+    if trials < 1:
+        raise ValueError(f"trials must be >= 1, got {trials}")
+
+    chosen = _resolve_algorithms(algorithms, algorithm_overrides)
+    if output_root is None:
+        output_root = Path("results") / f"experiment_{_utc_timestamp()}"
+    output_root = Path(output_root)
+    output_root.mkdir(parents=True, exist_ok=True)
+
+    results: list[TrialResult] = []
+    for algo_name, algo_fn in chosen.items():
+        for i in range(trials):
+            seed = base_seed + i
+            ts = _utc_timestamp()
+            run_dir = output_root / f"{algo_name}_trial_{i:03d}_{ts}"
+
+            best_template, logs = algo_fn(
+                config,
+                seed=seed,
+                output_dir=run_dir,
+                **algorithm_kwargs,
+            )
+            best_blended = max((log.best_blended for log in logs), default=float("-inf"))
+
+            result = TrialResult(
+                algorithm=algo_name,
+                trial_index=i,
+                seed=seed,
+                output_dir=run_dir,
+                best_template=best_template,
+                best_blended=best_blended,
+            )
+            results.append(result)
+            if progress is not None:
+                progress(result)
+
+    return results

--- a/src/experiment.py
+++ b/src/experiment.py
@@ -107,6 +107,8 @@ def _load_completed_trial(run_dir: Path) -> tuple[PromptTemplate, list[Generatio
             line = line.strip()
             if line:
                 logs.append(GenerationLog(**json.loads(line)))
+    if not logs:
+        raise ValueError(f"generations.jsonl in {run_dir} has no rows")
     return best_template, logs
 
 
@@ -163,10 +165,23 @@ def run_experiment(
         prior = _find_completed_trials(output_root, algo_name) if resume else {}
         for i in range(trials):
             seed = base_seed + i
+            resumed = False
             if i in prior:
                 # Resume: rebuild the TrialResult from the on-disk trial dir.
                 run_dir = prior[i]
-                best_template, logs = _load_completed_trial(run_dir)
+                try:
+                    best_template, logs = _load_completed_trial(run_dir)
+                    resumed = True
+                except (OSError, ValueError, TypeError, KeyError, json.JSONDecodeError):
+                    # Partial/corrupt prior output: rerun this trial fresh.
+                    ts = _utc_timestamp()
+                    run_dir = output_root / f"{algo_name}_trial_{i:03d}_{ts}"
+                    best_template, logs = algo_fn(
+                        config,
+                        seed=seed,
+                        output_dir=run_dir,
+                        **algorithm_kwargs,
+                    )
             else:
                 ts = _utc_timestamp()
                 run_dir = output_root / f"{algo_name}_trial_{i:03d}_{ts}"
@@ -187,7 +202,7 @@ def run_experiment(
                 output_dir=run_dir,
                 best_template=best_template,
                 best_blended=best_blended,
-                resumed=(i in prior),
+                resumed=resumed,
             )
             results.append(result)
             if progress is not None:

--- a/src/experiment.py
+++ b/src/experiment.py
@@ -233,7 +233,9 @@ def run_experiment(
             desc=label,
             unit="call",
             leave=True,
-            ncols=100,
+            dynamic_ncols=True,   # auto-fit to current terminal width
+            mininterval=0.25,     # throttle redraws so updates feel smooth
+            smoothing=0.1,        # weighted ETA averaging
         )
         try:
             user_gen = algorithm_kwargs.get("generate_summary")

--- a/src/experiment.py
+++ b/src/experiment.py
@@ -98,15 +98,23 @@ def _find_completed_trials(output_root: Path, algo: str) -> dict[int, Path]:
 
 def _load_completed_trial(run_dir: Path) -> tuple[PromptTemplate, list[GenerationLog]]:
     """Reconstruct an algorithm's return value from a finished trial dir."""
-    best_template = PromptTemplate.from_dict(
-        json.loads((run_dir / "best.json").read_text(encoding="utf-8"))
-    )
+    try:
+        best_template = PromptTemplate.from_dict(
+            json.loads((run_dir / "best.json").read_text(encoding="utf-8"))
+        )
+    except (TypeError, KeyError) as exc:
+        raise ValueError(f"best.json in {run_dir} has invalid schema") from exc
     logs: list[GenerationLog] = []
     with (run_dir / "generations.jsonl").open(encoding="utf-8") as f:
         for line in f:
             line = line.strip()
             if line:
-                logs.append(GenerationLog(**json.loads(line)))
+                try:
+                    logs.append(GenerationLog(**json.loads(line)))
+                except (TypeError, KeyError) as exc:
+                    raise ValueError(
+                        f"generations.jsonl in {run_dir} has invalid schema"
+                    ) from exc
     if not logs:
         raise ValueError(f"generations.jsonl in {run_dir} has no rows")
     return best_template, logs

--- a/src/fitness.py
+++ b/src/fitness.py
@@ -42,6 +42,7 @@ class FitnessConfig:
     lambda_len: float = 0.1
     lambda_fmt: float = 0.2
     max_prompt_tokens: int = 200
+    length_penalty_exponent: float = 2.0
 
     @classmethod
     def from_yaml(cls, path: Path = DEFAULT_CONFIG_PATH) -> "FitnessConfig":
@@ -90,9 +91,28 @@ def _format_violation_penalty(generated: str, reference: str) -> float:
     return 0.0
 
 
-def _length_penalty(prompt_token_count: int, max_tokens: int) -> float:
+def _length_penalty(
+    prompt_token_count: int,
+    max_tokens: int,
+    exponent: float = 2.0,
+) -> float:
+    """Length penalty with a hard floor at ``max_tokens`` and a configurable
+    growth curve past it.
+
+    * Below ``max_tokens``: penalty is 0 (so concise prompts are never
+      penalised). This is the "floor" the brief calls for.
+    * Past ``max_tokens``: penalty grows as ``(excess / max_tokens) ** exponent``.
+      With the default exponent of 2.0, the curve is gentle right after the
+      floor (e.g. 25% over -> 0.0625 penalty) and steep far above it (e.g.
+      doubled length -> 1.0 penalty, tripled -> 4.0). exponent=1.0 recovers
+      the old linear behaviour; exponent>2 tightens the curve further.
+    """
+    if max_tokens <= 0:
+        return 0.0
     excess = max(0, prompt_token_count - max_tokens)
-    return excess / max_tokens if max_tokens > 0 else 0.0
+    if excess == 0:
+        return 0.0
+    return (excess / max_tokens) ** exponent
 
 
 def score_prompt(
@@ -180,7 +200,11 @@ def score_prompt(
     fmt_pen_mean = sum(format_penalties) / n
 
     prompt_tokens = _approx_token_count(template.render_instructions())
-    len_pen = _length_penalty(prompt_tokens, config.max_prompt_tokens)
+    len_pen = _length_penalty(
+        prompt_tokens,
+        config.max_prompt_tokens,
+        exponent=config.length_penalty_exponent,
+    )
 
     blended = (
         config.alpha * rouge_mean

--- a/src/random_search.py
+++ b/src/random_search.py
@@ -117,14 +117,15 @@ def run_rs(
     output_dir: Optional[Path] = None,
     seed: int = 0,
     score_fn: Optional[Callable] = None,
-    workers: int = 8,
+    workers: Optional[int] = None,
 ) -> tuple[PromptTemplate, list[GenerationLog]]:
     """Run Random Search with the same total budget as the GA.
 
     Args:
         config: parsed config dict. When None, loads ``config.yaml`` from the
             repo root. Must contain ``ga.population_size`` and
-            ``ga.generations``; ``evaluation.eval_subset`` is honored if set.
+            ``ga.generations``; ``evaluation.eval_subset`` is honored if set;
+            ``ga.workers`` (if set) is honored for fairness with run_ga.
         generate_summary: callable forwarded to the fitness function;
             defaults to the OpenRouter-backed implementation in ``src.target_model``.
         functions: ordered function paths. Defaults to the full benchmark.
@@ -134,7 +135,9 @@ def run_rs(
         seed: RNG seed for template sampling. Same seed -> identical run.
         score_fn: fitness callable matching ``score_prompt``'s signature.
             Defaults to ``score_prompt``; injected for tests.
-        workers: thread pool size for parallel fitness evaluation.
+        workers: thread pool size. Defaults to ``ga.workers`` from config
+            (so RS gets the same parallelism as GA), falling back to 8 if
+            unset.
 
     Returns:
         ``(best_template, logs)`` where ``logs`` has length ``G``.
@@ -142,6 +145,8 @@ def run_rs(
     cfg = _load_config(config)
 
     ga_cfg = cfg.get("ga") or {}
+    if workers is None:
+        workers = int(ga_cfg.get("workers", 8))
     try:
         population_size = int(ga_cfg["population_size"])
         generations = int(ga_cfg["generations"])

--- a/src/random_search.py
+++ b/src/random_search.py
@@ -57,7 +57,9 @@ def _default_benchmark(
     """Pair every function file with its same-stem reference file.
 
     Fails loud if any function lacks a matching reference (or vice-versa) so
-    a missing data file can't silently shrink the benchmark.
+    a missing data file can't silently shrink the benchmark. Only source files
+    with ``.py``, ``.js``, or ``.ts`` extensions are considered benchmark
+    functions; metadata files (e.g. ``manifest.json``) are ignored.
     """
     supported_ext = {".py", ".js", ".ts"}
     fn_paths = sorted(

--- a/src/random_search.py
+++ b/src/random_search.py
@@ -92,7 +92,7 @@ def _default_benchmark(
             f"no benchmark pairs found under {functions_dir} / {references_dir}"
         )
     refs = [ref_by_stem[fn.stem] for fn in fn_paths]
-    return list(fn_paths), refs
+    return fn_paths, refs
 
 
 def _load_config(config: dict | None) -> dict:

--- a/src/random_search.py
+++ b/src/random_search.py
@@ -59,31 +59,40 @@ def _default_benchmark(
     Fails loud if any function lacks a matching reference (or vice-versa) so
     a missing data file can't silently shrink the benchmark.
     """
-    fn_paths = sorted(functions_dir.glob("*"))
-    fn_paths = [p for p in fn_paths if p.is_file()]
-    ref_by_stem = {p.stem: p for p in references_dir.glob("*") if p.is_file()}
+    supported_ext = {".py", ".js", ".ts"}
+    fn_paths = sorted(
+        p for p in functions_dir.iterdir()
+        if p.is_file() and p.suffix in supported_ext
+    )
+    ref_by_stem = {
+        p.stem: p for p in references_dir.iterdir()
+        if p.is_file() and not p.name.startswith(".")
+    }
 
-    fns: list[Path] = []
-    refs: list[Path] = []
-    missing: list[str] = []
-    for fn in fn_paths:
-        ref = ref_by_stem.get(fn.stem)
-        if ref is None:
-            missing.append(fn.name)
-            continue
-        fns.append(fn)
-        refs.append(ref)
-
-    if missing:
+    fn_stems = {p.stem for p in fn_paths}
+    missing = sorted(fn_stems - ref_by_stem.keys())
+    orphan_refs = sorted(ref_by_stem.keys() - fn_stems)
+    if missing or orphan_refs:
+        details = []
+        if missing:
+            details.append(
+                f"{len(missing)} function(s) without a matching reference: "
+                f"{missing[:5]}{'...' if len(missing) > 5 else ''}"
+            )
+        if orphan_refs:
+            details.append(
+                f"{len(orphan_refs)} reference(s) without functions: "
+                f"{orphan_refs[:5]}{'...' if len(orphan_refs) > 5 else ''}"
+            )
         raise ValueError(
-            f"benchmark pairing failed: {len(missing)} function(s) without a "
-            f"matching reference: {missing[:5]}{'...' if len(missing) > 5 else ''}"
+            "benchmark pairing failed: " + " | ".join(details)
         )
-    if not fns:
+    if not fn_paths:
         raise ValueError(
             f"no benchmark pairs found under {functions_dir} / {references_dir}"
         )
-    return fns, refs
+    refs = [ref_by_stem[fn.stem] for fn in fn_paths]
+    return list(fn_paths), refs
 
 
 def _load_config(config: dict | None) -> dict:

--- a/src/stats.py
+++ b/src/stats.py
@@ -1,0 +1,121 @@
+"""Statistical utilities for the GA-vs-RS comparison (issue #11).
+
+Two pure functions plus a thin combinator. They take two equal-purpose lists
+of best-of-trial fitness values (e.g. GA blended scores vs RS blended scores)
+and return the test statistics the paper reports.
+
+The functions deliberately do not log, plot, or read files; that lives in
+``scripts/analyze_results.py``. Keeping them pure makes them trivial to unit
+test and keeps the experiment harness reusable for follow-up studies.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, asdict
+from typing import Sequence
+
+from scipy.stats import ranksums
+
+
+# Romano et al. 2006 thresholds for Cliff's delta effect size.
+_CLIFFS_DELTA_THRESHOLDS = (
+    (0.147, "negligible"),
+    (0.33, "small"),
+    (0.474, "medium"),
+)
+
+
+@dataclass(frozen=True)
+class ComparisonResult:
+    """Wilcoxon rank-sum + Cliff's delta for one metric."""
+
+    metric: str
+    n_a: int
+    n_b: int
+    mean_a: float
+    mean_b: float
+    std_a: float
+    std_b: float
+    statistic: float
+    p_value: float
+    cliffs_delta: float
+    delta_label: str
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+
+def wilcoxon_ranksum(a: Sequence[float], b: Sequence[float]) -> tuple[float, float]:
+    """Two-sided Wilcoxon rank-sum test.
+
+    Returns ``(statistic, p_value)``. Wraps ``scipy.stats.ranksums`` so callers
+    do not import scipy directly.
+    """
+    if len(a) < 1 or len(b) < 1:
+        raise ValueError("both samples must be non-empty")
+    result = ranksums(list(a), list(b))
+    return float(result.statistic), float(result.pvalue)
+
+
+def cliffs_delta(a: Sequence[float], b: Sequence[float]) -> tuple[float, str]:
+    """Cliff's delta non-parametric effect size in [-1, 1].
+
+    Positive values mean A tends to be larger than B; magnitude is bucketed
+    using the Romano et al. (2006) thresholds (negligible / small / medium /
+    large) reported by the SBSE community.
+    """
+    if not a or not b:
+        raise ValueError("both samples must be non-empty")
+    n = len(a) * len(b)
+    greater = 0
+    less = 0
+    for x in a:
+        for y in b:
+            if x > y:
+                greater += 1
+            elif x < y:
+                less += 1
+    delta = (greater - less) / n
+    label = _delta_label(delta)
+    return float(delta), label
+
+
+def _delta_label(delta: float) -> str:
+    abs_d = abs(delta)
+    for threshold, name in _CLIFFS_DELTA_THRESHOLDS:
+        if abs_d < threshold:
+            return name
+    return "large"
+
+
+def compare_distributions(
+    a: Sequence[float],
+    b: Sequence[float],
+    *,
+    metric: str = "blended",
+) -> ComparisonResult:
+    """Run Wilcoxon + Cliff's delta and bundle the descriptive stats."""
+    if not a or not b:
+        raise ValueError(f"{metric}: both samples must be non-empty")
+    statistic, p = wilcoxon_ranksum(a, b)
+    delta, label = cliffs_delta(a, b)
+    return ComparisonResult(
+        metric=metric,
+        n_a=len(a),
+        n_b=len(b),
+        mean_a=float(sum(a) / len(a)),
+        mean_b=float(sum(b) / len(b)),
+        std_a=_std(a),
+        std_b=_std(b),
+        statistic=statistic,
+        p_value=p,
+        cliffs_delta=delta,
+        delta_label=label,
+    )
+
+
+def _std(values: Sequence[float]) -> float:
+    if len(values) < 2:
+        return 0.0
+    mean = sum(values) / len(values)
+    return float((sum((v - mean) ** 2 for v in values) / (len(values) - 1)) ** 0.5)

--- a/src/stats.py
+++ b/src/stats.py
@@ -51,7 +51,7 @@ def wilcoxon_ranksum(a: Sequence[float], b: Sequence[float]) -> tuple[float, flo
     Returns ``(statistic, p_value)``. Wraps ``scipy.stats.ranksums`` so callers
     do not import scipy directly.
     """
-    if len(a) < 1 or len(b) < 1:
+    if len(a) == 0 or len(b) == 0:
         raise ValueError("both samples must be non-empty")
     result = ranksums(list(a), list(b))
     return float(result.statistic), float(result.pvalue)
@@ -64,7 +64,7 @@ def cliffs_delta(a: Sequence[float], b: Sequence[float]) -> tuple[float, str]:
     using the Romano et al. (2006) thresholds (negligible / small / medium /
     large) reported by the SBSE community.
     """
-    if not a or not b:
+    if len(a) == 0 or len(b) == 0:
         raise ValueError("both samples must be non-empty")
     n = len(a) * len(b)
     greater = 0
@@ -95,7 +95,7 @@ def compare_distributions(
     metric: str = "blended",
 ) -> ComparisonResult:
     """Run Wilcoxon + Cliff's delta and bundle the descriptive stats."""
-    if not a or not b:
+    if len(a) == 0 or len(b) == 0:
         raise ValueError(f"{metric}: both samples must be non-empty")
     statistic, p = wilcoxon_ranksum(a, b)
     delta, label = cliffs_delta(a, b)

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -1,0 +1,175 @@
+"""Tests for src/analysis.py.
+
+Build synthetic trial directories on a tmp_path and verify the loader,
+trial summarizer, and end-to-end analysis pipeline.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from dataclasses import asdict
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+from src.analysis import (
+    PER_TRIAL_METRICS,
+    analyze_results_root,
+    discover_trial_dirs,
+    load_generation_logs,
+    summarize_trials,
+    trial_best,
+)
+from src.prompt import PromptTemplate
+from src.search_log import GenerationLog
+
+
+def _mk_log(gen: int, blended: float, rouge: float = 0.5, cos: float = 0.7) -> GenerationLog:
+    tmpl = PromptTemplate(role="r", task="t", guard="g", format="f")
+    return GenerationLog(
+        generation=gen,
+        best_blended=blended,
+        mean_blended=blended * 0.9,
+        worst_blended=blended * 0.8,
+        best_rouge_l=rouge,
+        best_cosine_raw=cos,
+        best_cosine_calibrated=cos * 0.7,
+        best_template=tmpl.to_dict(),
+    )
+
+
+def _write_trial(root: Path, name: str, logs: list[GenerationLog]) -> Path:
+    d = root / name
+    d.mkdir(parents=True, exist_ok=True)
+    with (d / "generations.jsonl").open("w") as f:
+        for log in logs:
+            f.write(json.dumps(asdict(log)) + "\n")
+    return d
+
+
+# ---------------------------------------------------------------------------
+# load_generation_logs
+# ---------------------------------------------------------------------------
+
+
+def test_load_generation_logs_round_trip(tmp_path: Path) -> None:
+    logs = [_mk_log(0, 0.5), _mk_log(1, 0.6)]
+    d = _write_trial(tmp_path, "ga_trial_000_x", logs)
+    loaded = load_generation_logs(d)
+    assert len(loaded) == 2
+    assert loaded[0] == logs[0]
+    assert loaded[1] == logs[1]
+
+
+def test_load_generation_logs_missing_file_raises(tmp_path: Path) -> None:
+    with pytest.raises(FileNotFoundError, match="generations.jsonl"):
+        load_generation_logs(tmp_path)
+
+
+def test_load_generation_logs_empty_file_raises(tmp_path: Path) -> None:
+    d = tmp_path / "empty"
+    d.mkdir()
+    (d / "generations.jsonl").write_text("")
+    with pytest.raises(ValueError, match="no rows"):
+        load_generation_logs(d)
+
+
+# ---------------------------------------------------------------------------
+# trial_best
+# ---------------------------------------------------------------------------
+
+
+def test_trial_best_picks_highest_blended() -> None:
+    logs = [
+        _mk_log(0, 0.4, rouge=0.1, cos=0.2),
+        _mk_log(1, 0.9, rouge=0.7, cos=0.8),  # winner
+        _mk_log(2, 0.6, rouge=0.5, cos=0.6),
+    ]
+    best = trial_best(logs)
+    assert best["blended"] == pytest.approx(0.9)
+    assert best["rouge_l"] == pytest.approx(0.7)
+    assert best["cosine_raw"] == pytest.approx(0.8)
+    assert best["cosine_calibrated"] == pytest.approx(0.8 * 0.7)
+
+
+def test_trial_best_rejects_empty() -> None:
+    with pytest.raises(ValueError, match="no logs"):
+        trial_best([])
+
+
+# ---------------------------------------------------------------------------
+# discover_trial_dirs
+# ---------------------------------------------------------------------------
+
+
+def test_discover_trial_dirs_groups_by_prefix(tmp_path: Path) -> None:
+    _write_trial(tmp_path, "ga_trial_000_a", [_mk_log(0, 0.5)])
+    _write_trial(tmp_path, "ga_trial_001_b", [_mk_log(0, 0.6)])
+    _write_trial(tmp_path, "rs_trial_000_c", [_mk_log(0, 0.4)])
+    (tmp_path / "not_a_trial_dir").mkdir()  # should be ignored
+    grouped = discover_trial_dirs(tmp_path)
+    assert set(grouped.keys()) == {"ga", "rs"}
+    assert len(grouped["ga"]) == 2
+    assert len(grouped["rs"]) == 1
+
+
+def test_discover_trial_dirs_missing_root_raises(tmp_path: Path) -> None:
+    with pytest.raises(FileNotFoundError, match="results root"):
+        discover_trial_dirs(tmp_path / "nope")
+
+
+# ---------------------------------------------------------------------------
+# summarize_trials
+# ---------------------------------------------------------------------------
+
+
+def test_summarize_trials_returns_per_metric_columns(tmp_path: Path) -> None:
+    d1 = _write_trial(tmp_path, "ga_trial_000_x", [_mk_log(0, 0.5)])
+    d2 = _write_trial(tmp_path, "ga_trial_001_y", [_mk_log(0, 0.7)])
+    cols = summarize_trials([d1, d2])
+    assert set(cols.keys()) == set(PER_TRIAL_METRICS)
+    assert cols["blended"] == pytest.approx([0.5, 0.7])
+
+
+# ---------------------------------------------------------------------------
+# End-to-end
+# ---------------------------------------------------------------------------
+
+
+def test_analyze_results_root_full_pipeline(tmp_path: Path) -> None:
+    # GA wins clearly: blended values 0.7-0.8 vs RS 0.3-0.4.
+    for i in range(5):
+        _write_trial(tmp_path, f"ga_trial_{i:03d}_x", [_mk_log(0, 0.7 + i * 0.02)])
+        _write_trial(tmp_path, f"rs_trial_{i:03d}_x", [_mk_log(0, 0.3 + i * 0.02)])
+
+    result = analyze_results_root(tmp_path)
+
+    assert result["target_algorithm"] == "ga"
+    assert result["baseline_algorithm"] == "rs"
+    assert result["n_trials"] == {"ga": 5, "rs": 5}
+    assert "blended" in result["comparisons"]
+
+    blended = result["comparisons"]["blended"]
+    assert blended["mean_a"] > blended["mean_b"]
+    assert blended["cliffs_delta"] == pytest.approx(1.0)
+    assert blended["delta_label"] == "large"
+    assert blended["p_value"] < 0.05  # n=5 vs n=5 with full domination
+
+
+def test_analyze_results_root_missing_algorithm_raises(tmp_path: Path) -> None:
+    _write_trial(tmp_path, "ga_trial_000_x", [_mk_log(0, 0.5)])
+    with pytest.raises(ValueError, match="rs"):
+        analyze_results_root(tmp_path)
+
+
+def test_analyze_results_root_per_trial_values_exposed(tmp_path: Path) -> None:
+    for i in range(3):
+        _write_trial(tmp_path, f"ga_trial_{i:03d}_x", [_mk_log(0, 0.5 + i * 0.1)])
+        _write_trial(tmp_path, f"rs_trial_{i:03d}_x", [_mk_log(0, 0.3 + i * 0.1)])
+    result = analyze_results_root(tmp_path)
+    assert result["per_trial_values"]["ga"]["blended"] == pytest.approx([0.5, 0.6, 0.7])
+    assert result["per_trial_values"]["rs"]["blended"] == pytest.approx([0.3, 0.4, 0.5])

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -154,10 +154,27 @@ def test_analyze_results_root_full_pipeline(tmp_path: Path) -> None:
     assert "blended" in result["comparisons"]
 
     blended = result["comparisons"]["blended"]
-    assert blended["mean_a"] > blended["mean_b"]
+    # Schema uses algorithm-named keys (matches issue #11 spec).
+    assert blended["ga_mean"] > blended["rs_mean"]
+    assert blended["n_ga"] == 5
+    assert blended["n_rs"] == 5
+    assert "ga_std" in blended and "rs_std" in blended
     assert blended["cliffs_delta"] == pytest.approx(1.0)
     assert blended["delta_label"] == "large"
     assert blended["p_value"] < 0.05  # n=5 vs n=5 with full domination
+
+
+def test_analyze_results_root_schema_uses_custom_algorithm_names(tmp_path: Path) -> None:
+    """Field-name renaming honors the actual --target / --baseline names."""
+    for i in range(3):
+        _write_trial(tmp_path, f"foo_trial_{i:03d}_x", [_mk_log(0, 0.5)])
+        _write_trial(tmp_path, f"bar_trial_{i:03d}_x", [_mk_log(0, 0.4)])
+
+    result = analyze_results_root(tmp_path, target_algorithm="foo", baseline_algorithm="bar")
+    blended = result["comparisons"]["blended"]
+    assert "foo_mean" in blended and "bar_mean" in blended
+    assert "foo_std" in blended and "bar_std" in blended
+    assert "n_foo" in blended and "n_bar" in blended
 
 
 def test_analyze_results_root_missing_algorithm_raises(tmp_path: Path) -> None:

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -7,6 +7,7 @@ output-dir layout, and that the progress callback fires.
 
 from __future__ import annotations
 
+import json
 import sys
 from pathlib import Path
 
@@ -299,3 +300,43 @@ def test_resume_ignores_partial_trial_dir(tmp_path: Path) -> None:
     )
     # Trial 0 was incomplete -> ran fresh.
     assert len(ga_calls) == 1
+
+
+def test_resume_reruns_corrupt_completed_trial_dir(tmp_path: Path) -> None:
+    d = tmp_path / "ga_trial_000_corrupt"
+    d.mkdir()
+    (d / "best.json").write_text("{not-json}", encoding="utf-8")
+    (d / "generations.jsonl").write_text("{}", encoding="utf-8")
+
+    ga_calls: list[dict] = []
+    results = run_experiment(
+        {},
+        trials=1,
+        output_root=tmp_path,
+        algorithms=["ga"],
+        algorithm_overrides={"ga": _make_mock_algo(0.8, ga_calls)},
+        resume=True,
+    )
+
+    assert len(ga_calls) == 1
+    assert results[0].resumed is False
+
+
+def test_resume_reruns_empty_generations_even_with_best_json(tmp_path: Path) -> None:
+    d = tmp_path / "ga_trial_000_empty"
+    d.mkdir()
+    (d / "best.json").write_text(json.dumps(_mk_template().to_dict()), encoding="utf-8")
+    (d / "generations.jsonl").write_text("", encoding="utf-8")
+
+    ga_calls: list[dict] = []
+    results = run_experiment(
+        {},
+        trials=1,
+        output_root=tmp_path,
+        algorithms=["ga"],
+        algorithm_overrides={"ga": _make_mock_algo(0.8, ga_calls)},
+        resume=True,
+    )
+
+    assert len(ga_calls) == 1
+    assert results[0].resumed is False

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -401,3 +401,23 @@ def test_resume_reruns_empty_generations_even_with_best_json(tmp_path: Path) -> 
 
     assert len(ga_calls) == 1
     assert results[0].resumed is False
+
+
+def test_resume_reruns_invalid_generations_schema(tmp_path: Path) -> None:
+    d = tmp_path / "ga_trial_000_invalid_schema"
+    d.mkdir()
+    (d / "best.json").write_text(json.dumps(_mk_template().to_dict()), encoding="utf-8")
+    (d / "generations.jsonl").write_text("{}\n", encoding="utf-8")
+
+    ga_calls: list[dict] = []
+    results = run_experiment(
+        {},
+        trials=1,
+        output_root=tmp_path,
+        algorithms=["ga"],
+        algorithm_overrides={"ga": _make_mock_algo(0.8, ga_calls)},
+        resume=True,
+    )
+
+    assert len(ga_calls) == 1
+    assert results[0].resumed is False

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -404,6 +404,7 @@ def test_resume_reruns_empty_generations_even_with_best_json(tmp_path: Path) -> 
 
 
 def test_resume_reruns_invalid_generations_schema(tmp_path: Path) -> None:
+    """generations.jsonl with valid JSON but wrong shape (e.g. {}) -> rerun."""
     d = tmp_path / "ga_trial_000_invalid_schema"
     d.mkdir()
     (d / "best.json").write_text(json.dumps(_mk_template().to_dict()), encoding="utf-8")
@@ -421,3 +422,30 @@ def test_resume_reruns_invalid_generations_schema(tmp_path: Path) -> None:
 
     assert len(ga_calls) == 1
     assert results[0].resumed is False
+
+
+def test_resume_reruns_schema_invalid_completed_trial_dir(tmp_path: Path) -> None:
+    """Both best.json AND generations.jsonl have wrong shape -> rerun.
+    Covers the codex P2 finding that TypeError from GenerationLog(**row)
+    used to escape and abort the whole experiment instead of being treated
+    as a corrupt completed-looking trial dir.
+    """
+    import json as _json
+
+    d = tmp_path / "ga_trial_000_corrupt"
+    d.mkdir()
+    (d / "best.json").write_text("{}", encoding="utf-8")  # missing required fields
+    with (d / "generations.jsonl").open("w") as f:
+        f.write(_json.dumps({"k": "v"}) + "\n")  # not a GenerationLog row
+
+    ga_calls: list[dict] = []
+    run_experiment(
+        {},
+        trials=1,
+        output_root=tmp_path,
+        algorithms=["ga"],
+        algorithm_overrides={"ga": _make_mock_algo(0.7, ga_calls)},
+        resume=True,
+    )
+    # Trial 0's best.json was schema-invalid -> we re-ran instead of crashing.
+    assert len(ga_calls) == 1

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -186,3 +186,116 @@ def test_run_experiment_rejects_unknown_algorithm(tmp_path: Path) -> None:
         run_experiment(
             {}, trials=1, output_root=tmp_path, algorithms=["does-not-exist"],
         )
+
+
+# ---------------------------------------------------------------------------
+# Resume behavior
+# ---------------------------------------------------------------------------
+
+
+def _seed_completed_trial(
+    output_root: Path,
+    algo: str,
+    trial_index: int,
+    *,
+    blended: float = 0.77,
+    n_logs: int = 3,
+) -> Path:
+    """Pre-create a fully-completed trial directory on disk."""
+    import json
+    from dataclasses import asdict
+    d = output_root / f"{algo}_trial_{trial_index:03d}_2026-pre"
+    d.mkdir(parents=True)
+    template = _mk_template(role=f"resumed-{algo}-{trial_index}")
+    (d / "best.json").write_text(json.dumps(template.to_dict()), encoding="utf-8")
+    logs = _mk_logs(blended, n=n_logs)
+    with (d / "generations.jsonl").open("w") as f:
+        for log in logs:
+            f.write(json.dumps(asdict(log)) + "\n")
+    return d
+
+
+def test_resume_skips_completed_trials(tmp_path: Path) -> None:
+    """Pre-seeded GA trial 0 should be loaded, not re-run."""
+    _seed_completed_trial(tmp_path, "ga", 0, blended=0.91)
+
+    ga_calls: list[dict] = []
+    rs_calls: list[dict] = []
+
+    results = run_experiment(
+        {},
+        trials=2,
+        output_root=tmp_path,
+        algorithm_overrides={
+            "ga": _make_mock_algo(0.5, ga_calls),
+            "rs": _make_mock_algo(0.4, rs_calls),
+        },
+        resume=True,
+    )
+
+    # Only GA trial 1 (and both RS trials) should have actually run.
+    assert len(ga_calls) == 1
+    assert ga_calls[0]["seed"] == 1
+    assert len(rs_calls) == 2
+
+    ga_results = sorted([r for r in results if r.algorithm == "ga"],
+                        key=lambda r: r.trial_index)
+    assert ga_results[0].resumed is True
+    assert ga_results[0].best_blended == pytest.approx(0.91)
+    assert ga_results[0].best_template.role == "resumed-ga-0"
+    assert ga_results[1].resumed is False
+
+
+def test_resume_false_forces_rerun_of_all_trials(tmp_path: Path) -> None:
+    _seed_completed_trial(tmp_path, "ga", 0, blended=0.91)
+
+    ga_calls: list[dict] = []
+    run_experiment(
+        {},
+        trials=2,
+        output_root=tmp_path,
+        algorithms=["ga"],
+        algorithm_overrides={"ga": _make_mock_algo(0.5, ga_calls)},
+        resume=False,
+    )
+    # Even though trial 0 exists on disk, --no-resume runs it again.
+    assert len(ga_calls) == 2
+
+
+def test_resume_with_nothing_to_resume_runs_all(tmp_path: Path) -> None:
+    ga_calls: list[dict] = []
+    run_experiment(
+        {},
+        trials=3,
+        output_root=tmp_path,
+        algorithms=["ga"],
+        algorithm_overrides={"ga": _make_mock_algo(0.7, ga_calls)},
+        resume=True,
+    )
+    # Empty output_root -> every trial runs.
+    assert len(ga_calls) == 3
+    assert [c["seed"] for c in ga_calls] == [0, 1, 2]
+
+
+def test_resume_ignores_partial_trial_dir(tmp_path: Path) -> None:
+    """A trial dir with generations.jsonl but no best.json is NOT complete."""
+    import json
+    from dataclasses import asdict
+    d = tmp_path / "ga_trial_000_partial"
+    d.mkdir()
+    log = _mk_logs(0.5, n=1)[0]
+    with (d / "generations.jsonl").open("w") as f:
+        f.write(json.dumps(asdict(log)) + "\n")
+    # No best.json -> incomplete.
+
+    ga_calls: list[dict] = []
+    run_experiment(
+        {},
+        trials=1,
+        output_root=tmp_path,
+        algorithms=["ga"],
+        algorithm_overrides={"ga": _make_mock_algo(0.8, ga_calls)},
+        resume=True,
+    )
+    # Trial 0 was incomplete -> ran fresh.
+    assert len(ga_calls) == 1

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -1,0 +1,188 @@
+"""Tests for src/experiment.py.
+
+The orchestrator is exercised with mock algorithm callables so we don't pay
+fitness cost or hit the LLM. We just verify trial counts, seed sequencing,
+output-dir layout, and that the progress callback fires.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+from src.experiment import TrialResult, run_experiment
+from src.prompt import PromptTemplate
+from src.search_log import GenerationLog
+
+
+def _mk_template(role: str = "r") -> PromptTemplate:
+    return PromptTemplate(role=role, task="t", guard="g", format="f")
+
+
+def _mk_logs(best_blended: float, n: int = 3) -> list[GenerationLog]:
+    return [
+        GenerationLog(
+            generation=i,
+            best_blended=best_blended,
+            mean_blended=best_blended * 0.9,
+            worst_blended=best_blended * 0.8,
+            best_rouge_l=best_blended * 0.7,
+            best_cosine_raw=best_blended * 0.8,
+            best_cosine_calibrated=best_blended * 0.6,
+            best_template=_mk_template().to_dict(),
+        )
+        for i in range(n)
+    ]
+
+
+def _make_mock_algo(score: float, captured: list[dict]):
+    """Return an algorithm fn that records its kwargs and writes nothing."""
+    def _fn(config, *, seed, output_dir, **kwargs):  # noqa: ARG001
+        captured.append({"seed": seed, "output_dir": output_dir, **kwargs})
+        # Mimic the real algorithms: create the dir even if no files written.
+        Path(output_dir).mkdir(parents=True, exist_ok=True)
+        return _mk_template(role=f"score-{score}"), _mk_logs(score)
+    return _fn
+
+
+# ---------------------------------------------------------------------------
+# Core behavior
+# ---------------------------------------------------------------------------
+
+
+def test_run_experiment_runs_each_algorithm_n_times(tmp_path: Path) -> None:
+    ga_calls: list[dict] = []
+    rs_calls: list[dict] = []
+
+    results = run_experiment(
+        {"ga": {"population_size": 2, "generations": 2}},
+        trials=3,
+        output_root=tmp_path,
+        algorithm_overrides={
+            "ga": _make_mock_algo(0.8, ga_calls),
+            "rs": _make_mock_algo(0.5, rs_calls),
+        },
+    )
+
+    assert len(results) == 6  # 3 trials × 2 algos
+    assert len(ga_calls) == 3
+    assert len(rs_calls) == 3
+
+
+def test_run_experiment_seed_increments_per_trial(tmp_path: Path) -> None:
+    seen: list[dict] = []
+    run_experiment(
+        {},
+        trials=3,
+        output_root=tmp_path,
+        algorithms=["ga"],
+        algorithm_overrides={"ga": _make_mock_algo(0.7, seen)},
+        base_seed=42,
+    )
+    assert [c["seed"] for c in seen] == [42, 43, 44]
+
+
+def test_run_experiment_matched_seeds_across_algorithms(tmp_path: Path) -> None:
+    """GA trial i and RS trial i share a seed so each pair sees the same RNG."""
+    ga_seen: list[dict] = []
+    rs_seen: list[dict] = []
+    run_experiment(
+        {},
+        trials=3,
+        output_root=tmp_path,
+        algorithm_overrides={
+            "ga": _make_mock_algo(0.8, ga_seen),
+            "rs": _make_mock_algo(0.5, rs_seen),
+        },
+    )
+    ga_seeds = [c["seed"] for c in ga_seen]
+    rs_seeds = [c["seed"] for c in rs_seen]
+    assert ga_seeds == rs_seeds == [0, 1, 2]
+
+
+def test_run_experiment_writes_per_trial_subdirs(tmp_path: Path) -> None:
+    run_experiment(
+        {},
+        trials=2,
+        output_root=tmp_path,
+        algorithm_overrides={
+            "ga": _make_mock_algo(0.8, []),
+            "rs": _make_mock_algo(0.5, []),
+        },
+    )
+    children = sorted(p.name for p in tmp_path.iterdir() if p.is_dir())
+    assert len(children) == 4
+    assert sum(1 for c in children if c.startswith("ga_trial_")) == 2
+    assert sum(1 for c in children if c.startswith("rs_trial_")) == 2
+
+
+def test_run_experiment_returns_best_blended_from_logs(tmp_path: Path) -> None:
+    results = run_experiment(
+        {},
+        trials=2,
+        output_root=tmp_path,
+        algorithm_overrides={
+            "ga": _make_mock_algo(0.85, []),
+            "rs": _make_mock_algo(0.55, []),
+        },
+    )
+    ga = [r for r in results if r.algorithm == "ga"]
+    rs = [r for r in results if r.algorithm == "rs"]
+    assert all(r.best_blended == pytest.approx(0.85) for r in ga)
+    assert all(r.best_blended == pytest.approx(0.55) for r in rs)
+
+
+def test_run_experiment_progress_callback_fires_per_trial(tmp_path: Path) -> None:
+    seen: list[TrialResult] = []
+    run_experiment(
+        {},
+        trials=2,
+        output_root=tmp_path,
+        algorithm_overrides={
+            "ga": _make_mock_algo(0.8, []),
+            "rs": _make_mock_algo(0.5, []),
+        },
+        progress=seen.append,
+    )
+    assert len(seen) == 4
+    assert all(isinstance(r, TrialResult) for r in seen)
+
+
+def test_run_experiment_forwards_algorithm_kwargs(tmp_path: Path) -> None:
+    captured: list[dict] = []
+    run_experiment(
+        {},
+        trials=1,
+        output_root=tmp_path,
+        algorithms=["ga"],
+        algorithm_overrides={"ga": _make_mock_algo(0.9, captured)},
+        score_fn="my-score-fn",  # arbitrary marker
+        functions=["a.py"],
+    )
+    assert captured[0]["score_fn"] == "my-score-fn"
+    assert captured[0]["functions"] == ["a.py"]
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+
+def test_run_experiment_rejects_zero_trials(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="trials"):
+        run_experiment(
+            {}, trials=0, output_root=tmp_path,
+            algorithm_overrides={"ga": _make_mock_algo(0.8, [])},
+        )
+
+
+def test_run_experiment_rejects_unknown_algorithm(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="unknown algorithm"):
+        run_experiment(
+            {}, trials=1, output_root=tmp_path, algorithms=["does-not-exist"],
+        )

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -278,6 +278,67 @@ def test_resume_with_nothing_to_resume_runs_all(tmp_path: Path) -> None:
     assert [c["seed"] for c in ga_calls] == [0, 1, 2]
 
 
+# ---------------------------------------------------------------------------
+# show_progress wiring
+# ---------------------------------------------------------------------------
+
+
+def test_show_progress_wraps_generate_summary_and_ticks_bar(tmp_path: Path) -> None:
+    """When show_progress=True, the algorithm receives a wrapped
+    generate_summary that ticks a tqdm bar after each underlying call."""
+    call_log: list[str] = []
+
+    def fake_generate(template, code):  # noqa: ARG001
+        call_log.append(code)
+        return "ok"
+
+    def algo_that_invokes_generator(config, *, seed, output_dir, **kwargs):  # noqa: ARG001
+        Path(output_dir).mkdir(parents=True, exist_ok=True)
+        gs = kwargs["generate_summary"]
+        # Make 4 calls so we can verify ticks.
+        for i in range(4):
+            gs(_mk_template(), f"code-{i}")
+        return _mk_template(role="done"), _mk_logs(0.7, n=2)
+
+    config = {
+        "ga": {"population_size": 2, "generations": 2},
+        "evaluation": {"eval_subset": 1},
+    }
+    run_experiment(
+        config,
+        trials=1,
+        output_root=tmp_path,
+        algorithms=["ga"],
+        algorithm_overrides={"ga": algo_that_invokes_generator},
+        generate_summary=fake_generate,
+        show_progress=True,
+    )
+    # The wrapped generator forwards to fake_generate -> 4 calls observed.
+    assert call_log == ["code-0", "code-1", "code-2", "code-3"]
+
+
+def test_show_progress_off_does_not_wrap(tmp_path: Path) -> None:
+    received_kwargs: dict = {}
+
+    def algo_capturing(config, *, seed, output_dir, **kwargs):  # noqa: ARG001
+        received_kwargs.update(kwargs)
+        Path(output_dir).mkdir(parents=True, exist_ok=True)
+        return _mk_template(), _mk_logs(0.5, n=1)
+
+    sentinel = object()
+    run_experiment(
+        {},
+        trials=1,
+        output_root=tmp_path,
+        algorithms=["ga"],
+        algorithm_overrides={"ga": algo_capturing},
+        generate_summary=sentinel,
+        show_progress=False,
+    )
+    # No wrapping -> the algorithm received our exact sentinel.
+    assert received_kwargs["generate_summary"] is sentinel
+
+
 def test_resume_ignores_partial_trial_dir(tmp_path: Path) -> None:
     """A trial dir with generations.jsonl but no best.json is NOT complete."""
     import json

--- a/tests/test_fitness.py
+++ b/tests/test_fitness.py
@@ -183,6 +183,44 @@ def test_short_prompt_has_no_length_penalty(benchmark) -> None:
     assert result["length_penalty"] == 0.0
 
 
+def test_length_penalty_quadratic_growth_past_floor() -> None:
+    """Default exponent=2.0 -> 25% over yields ~0.0625, doubled length yields 1.0."""
+    from src.fitness import _length_penalty
+    assert _length_penalty(200, 200, exponent=2.0) == 0.0          # at floor
+    assert _length_penalty(150, 200, exponent=2.0) == 0.0          # below floor
+    assert _length_penalty(250, 200, exponent=2.0) == pytest.approx(0.0625)  # 25% over
+    assert _length_penalty(400, 200, exponent=2.0) == pytest.approx(1.0)     # 2x floor
+    assert _length_penalty(600, 200, exponent=2.0) == pytest.approx(4.0)     # 3x floor
+
+
+def test_length_penalty_linear_when_exponent_is_one() -> None:
+    """exponent=1.0 recovers the original linear penalty for backwards comparison."""
+    from src.fitness import _length_penalty
+    assert _length_penalty(250, 200, exponent=1.0) == pytest.approx(0.25)
+    assert _length_penalty(400, 200, exponent=1.0) == pytest.approx(1.0)
+    assert _length_penalty(600, 200, exponent=1.0) == pytest.approx(2.0)
+
+
+def test_length_penalty_exponent_is_read_from_config(benchmark) -> None:
+    """A higher exponent makes the same overage hurt more in the blended score."""
+    fns, refs = benchmark
+    long_role = "word " * 500
+    template = PromptTemplate(role=long_role, task="t", guard="g", format="f")
+
+    with patch.object(fitness_mod, "cosine_similarity_batch", return_value=[0.5] * len(fns)):
+        soft = score_prompt(
+            template, fns, refs,
+            generate_summary=_make_gen(["s"] * len(fns)),
+            config=FitnessConfig(max_prompt_tokens=50, length_penalty_exponent=1.0),
+        )
+        harsh = score_prompt(
+            template, fns, refs,
+            generate_summary=_make_gen(["s"] * len(fns)),
+            config=FitnessConfig(max_prompt_tokens=50, length_penalty_exponent=3.0),
+        )
+    assert harsh["length_penalty"] > soft["length_penalty"]
+
+
 # ---------------------------------------------------------------------------
 # Calibration is wired through correctly
 # ---------------------------------------------------------------------------

--- a/tests/test_random_search.py
+++ b/tests/test_random_search.py
@@ -328,13 +328,17 @@ def test_default_benchmark_ignores_non_benchmark_files(tmp_path: Path) -> None:
     fn_dir.mkdir()
     ref_dir.mkdir()
     (fn_dir / "a.js").write_text("function a(){}")
+    (fn_dir / "b.py").write_text("def b(): pass")
+    (fn_dir / "c.ts").write_text("function c(): void {}")
     (fn_dir / "manifest.json").write_text("{}")
     (ref_dir / "a.txt").write_text("a")
+    (ref_dir / "b.txt").write_text("b")
+    (ref_dir / "c.txt").write_text("c")
     (ref_dir / ".gitkeep").write_text("")
 
     fns, refs = _default_benchmark(fn_dir, ref_dir)
-    assert [p.name for p in fns] == ["a.js"]
-    assert [p.name for p in refs] == ["a.txt"]
+    assert [p.name for p in fns] == ["a.js", "b.py", "c.ts"]
+    assert [p.name for p in refs] == ["a.txt", "b.txt", "c.txt"]
 
 
 def test_default_benchmark_pairs_by_stem(tmp_path: Path) -> None:

--- a/tests/test_random_search.py
+++ b/tests/test_random_search.py
@@ -322,6 +322,21 @@ def test_default_benchmark_raises_on_unpaired(tmp_path: Path) -> None:
         _default_benchmark(fn_dir, ref_dir)
 
 
+def test_default_benchmark_ignores_non_benchmark_files(tmp_path: Path) -> None:
+    fn_dir = tmp_path / "functions"
+    ref_dir = tmp_path / "references"
+    fn_dir.mkdir()
+    ref_dir.mkdir()
+    (fn_dir / "a.js").write_text("function a(){}")
+    (fn_dir / "manifest.json").write_text("{}")
+    (ref_dir / "a.txt").write_text("a")
+    (ref_dir / ".gitkeep").write_text("")
+
+    fns, refs = _default_benchmark(fn_dir, ref_dir)
+    assert [p.name for p in fns] == ["a.js"]
+    assert [p.name for p in refs] == ["a.txt"]
+
+
 def test_default_benchmark_pairs_by_stem(tmp_path: Path) -> None:
     fn_dir = tmp_path / "functions"
     ref_dir = tmp_path / "references"
@@ -334,6 +349,18 @@ def test_default_benchmark_pairs_by_stem(tmp_path: Path) -> None:
     fns, refs = _default_benchmark(fn_dir, ref_dir)
     assert [p.stem for p in fns] == [p.stem for p in refs]
     assert len(fns) == 2
+
+
+def test_default_benchmark_raises_on_orphan_reference(tmp_path: Path) -> None:
+    fn_dir = tmp_path / "functions"
+    ref_dir = tmp_path / "references"
+    fn_dir.mkdir()
+    ref_dir.mkdir()
+    (fn_dir / "a.js").write_text("function a(){}")
+    (ref_dir / "a.txt").write_text("a")
+    (ref_dir / "b.txt").write_text("b")
+    with pytest.raises(ValueError, match="without functions"):
+        _default_benchmark(fn_dir, ref_dir)
 
 
 def test_default_benchmark_raises_on_empty(tmp_path: Path) -> None:

--- a/tests/test_random_search.py
+++ b/tests/test_random_search.py
@@ -401,3 +401,67 @@ def test_run_rs_rejects_non_positive_budget(benchmark, tmp_path: Path) -> None:
             functions=fns, references=refs,
             output_dir=tmp_path / "out", score_fn=mock,
         )
+
+
+def test_run_rs_reads_workers_from_ga_config(benchmark, tmp_path: Path) -> None:
+    """workers defaults to ga.workers in config so RS matches GA's parallelism."""
+    from unittest.mock import patch
+    from src import random_search as rs_mod
+
+    fns, refs = benchmark
+    mock, _ = _make_mock_score_fn()
+
+    captured: dict = {}
+
+    class _SpyExecutor:
+        def __init__(self, *args, **kwargs):
+            captured["max_workers"] = kwargs.get("max_workers")
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            return False
+
+        def map(self, fn, items):
+            return [fn(x) for x in items]
+
+    with patch.object(rs_mod, "ThreadPoolExecutor", _SpyExecutor):
+        run_rs(
+            {"ga": {"population_size": 2, "generations": 1, "workers": 13}},
+            functions=fns, references=refs,
+            output_dir=tmp_path / "out", score_fn=mock,
+        )
+    assert captured["max_workers"] == 13
+
+
+def test_run_rs_workers_kwarg_overrides_config(benchmark, tmp_path: Path) -> None:
+    """Explicit workers= kwarg wins over config ga.workers."""
+    from unittest.mock import patch
+    from src import random_search as rs_mod
+
+    fns, refs = benchmark
+    mock, _ = _make_mock_score_fn()
+    captured: dict = {}
+
+    class _SpyExecutor:
+        def __init__(self, *args, **kwargs):
+            captured["max_workers"] = kwargs.get("max_workers")
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            return False
+
+        def map(self, fn, items):
+            return [fn(x) for x in items]
+
+    with patch.object(rs_mod, "ThreadPoolExecutor", _SpyExecutor):
+        run_rs(
+            {"ga": {"population_size": 2, "generations": 1, "workers": 13}},
+            functions=fns, references=refs,
+            output_dir=tmp_path / "out", score_fn=mock,
+            workers=5,  # should override the config value
+        )
+    assert captured["max_workers"] == 5

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -1,0 +1,122 @@
+"""Tests for src/stats.py."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+from src.stats import (
+    ComparisonResult,
+    cliffs_delta,
+    compare_distributions,
+    wilcoxon_ranksum,
+)
+
+
+# ---------------------------------------------------------------------------
+# Wilcoxon rank-sum
+# ---------------------------------------------------------------------------
+
+
+def test_wilcoxon_same_distribution_high_p() -> None:
+    a = [0.5, 0.6, 0.55, 0.52, 0.58, 0.51, 0.57, 0.53, 0.56, 0.54]
+    b = [0.5, 0.6, 0.55, 0.52, 0.58, 0.51, 0.57, 0.53, 0.56, 0.54]
+    _, p = wilcoxon_ranksum(a, b)
+    assert p > 0.5
+
+
+def test_wilcoxon_clearly_different_distributions_low_p() -> None:
+    a = [0.9, 0.92, 0.88, 0.91, 0.93, 0.89, 0.94, 0.9, 0.91, 0.92]
+    b = [0.1, 0.12, 0.08, 0.11, 0.13, 0.09, 0.14, 0.1, 0.11, 0.12]
+    _, p = wilcoxon_ranksum(a, b)
+    assert p < 0.001
+
+
+def test_wilcoxon_rejects_empty() -> None:
+    with pytest.raises(ValueError, match="non-empty"):
+        wilcoxon_ranksum([], [0.5])
+
+
+# ---------------------------------------------------------------------------
+# Cliff's delta
+# ---------------------------------------------------------------------------
+
+
+def test_cliffs_delta_identical_is_zero() -> None:
+    a = [0.5, 0.6, 0.7]
+    delta, label = cliffs_delta(a, a)
+    assert delta == 0.0
+    assert label == "negligible"
+
+
+def test_cliffs_delta_a_dominates_is_one() -> None:
+    a = [0.9, 0.95, 0.92]
+    b = [0.1, 0.2, 0.15]
+    delta, label = cliffs_delta(a, b)
+    assert delta == pytest.approx(1.0)
+    assert label == "large"
+
+
+def test_cliffs_delta_b_dominates_is_negative_one() -> None:
+    a = [0.1, 0.2]
+    b = [0.9, 0.95]
+    delta, _ = cliffs_delta(a, b)
+    assert delta == pytest.approx(-1.0)
+
+
+def test_cliffs_delta_label_thresholds() -> None:
+    # negligible: identical distributions -> delta = 0
+    assert cliffs_delta([1, 2, 3], [1, 2, 3])[1] == "negligible"
+    # large: full domination -> |delta| = 1
+    assert cliffs_delta([1, 2, 3], [-1, -2, -3])[1] == "large"
+    # small: ~10% net win rate (delta around 0.2)
+    a = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+    b = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]  # shifted by 1
+    delta, label = cliffs_delta(a, b)
+    assert 0.147 <= abs(delta) < 0.33
+    assert label == "small"
+
+
+def test_cliffs_delta_rejects_empty() -> None:
+    with pytest.raises(ValueError, match="non-empty"):
+        cliffs_delta([], [0.5])
+
+
+# ---------------------------------------------------------------------------
+# compare_distributions
+# ---------------------------------------------------------------------------
+
+
+def test_compare_distributions_returns_full_result() -> None:
+    ga = [0.7, 0.72, 0.75, 0.71, 0.74, 0.73, 0.7, 0.76, 0.72, 0.73]
+    rs = [0.6, 0.62, 0.65, 0.61, 0.64, 0.63, 0.6, 0.66, 0.62, 0.63]
+    result = compare_distributions(ga, rs, metric="blended")
+    assert isinstance(result, ComparisonResult)
+    assert result.metric == "blended"
+    assert result.n_a == 10
+    assert result.n_b == 10
+    assert result.mean_a > result.mean_b
+    assert result.cliffs_delta > 0  # GA > RS
+    assert result.p_value < 0.01  # clearly different
+
+
+def test_compare_distributions_to_dict_is_serializable() -> None:
+    result = compare_distributions([0.5, 0.6], [0.4, 0.5], metric="rouge_l")
+    d = result.to_dict()
+    assert set(d.keys()) >= {
+        "metric", "n_a", "n_b", "mean_a", "mean_b", "std_a", "std_b",
+        "statistic", "p_value", "cliffs_delta", "delta_label",
+    }
+    # All numeric fields are JSON-friendly floats.
+    import json
+    json.dumps(d)
+
+
+def test_compare_distributions_rejects_empty() -> None:
+    with pytest.raises(ValueError, match="non-empty"):
+        compare_distributions([], [0.5], metric="blended")

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -6,6 +6,7 @@ import sys
 from pathlib import Path
 
 import pytest
+np = pytest.importorskip("numpy")
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO_ROOT))
@@ -87,6 +88,12 @@ def test_cliffs_delta_rejects_empty() -> None:
         cliffs_delta([], [0.5])
 
 
+def test_cliffs_delta_accepts_numpy_arrays() -> None:
+    delta, label = cliffs_delta(np.array([0.9, 0.95]), np.array([0.1, 0.2]))
+    assert delta > 0
+    assert label == "large"
+
+
 # ---------------------------------------------------------------------------
 # compare_distributions
 # ---------------------------------------------------------------------------
@@ -120,3 +127,8 @@ def test_compare_distributions_to_dict_is_serializable() -> None:
 def test_compare_distributions_rejects_empty() -> None:
     with pytest.raises(ValueError, match="non-empty"):
         compare_distributions([], [0.5], metric="blended")
+
+
+def test_compare_distributions_rejects_empty_numpy_arrays() -> None:
+    with pytest.raises(ValueError, match="non-empty"):
+        compare_distributions(np.array([]), np.array([0.5]), metric="blended")


### PR DESCRIPTION
Closes #11. Final piece — turns the merged GA/RS algorithms into a publishable comparison.

## What's new
- `src/stats.py` — pure `wilcoxon_ranksum`, `cliffs_delta` (Romano et al. 2006 effect-size labels), and `compare_distributions` combinator
- `src/experiment.py` — `run_experiment(...)` orchestrator: loops trials × algorithms with **matched seeds** (GA trial *i* and RS trial *i* share `seed = base_seed + i`), writes per-trial subdirs, supports algorithm injection for testing
- `src/analysis.py` — loads experiment dirs, picks each trial's winning generation by `max(best_blended)`, runs comparisons across all four metrics
- `scripts/run_experiment.py` — CLI entry point with live per-trial progress, writes `manifest.json`, auto-invokes the analysis script at the end
- `scripts/analyze_results.py` — writes `statistical_summary.json` + prints a stdout table
- `scripts/plot_convergence.py` — three-panel matplotlib figure (blended / ROUGE-L / cosine_calibrated) with mean ± std bands

## How to run the experiment

```bash
# Full default experiment (10 trials × 2 algorithms)
.venv/bin/python scripts/run_experiment.py

# Quick smoke (3 trials, GA only)
.venv/bin/python scripts/run_experiment.py --trials 3 --algorithm ga

# Re-analyze an existing run
.venv/bin/python scripts/analyze_results.py \
  --results-root results/experiment_<ts>/ \
  --output     results/experiment_<ts>/statistical_summary.json

# Generate the paper figure
.venv/bin/python scripts/plot_convergence.py \
  --results-root results/experiment_<ts>/ \
  --output     results/experiment_<ts>/convergence.png
```

## Per-trial directory layout

```
results/experiment_<ts>/
  ga_trial_000_<ts>/
    generations.jsonl     # one row per generation, flushed in real time
    best.json             # all-time best PromptTemplate
  ga_trial_001_<ts>/
  ...
  rs_trial_000_<ts>/
  ...
  manifest.json           # per-trial summary, written when orchestrator finishes
  statistical_summary.json   # Wilcoxon + Cliff's delta per metric
  convergence.png         # if you ran plot_convergence.py
```

## Statistical methodology
- Wilcoxon rank-sum (two-sided, α = 0.05) on best-of-trial blended scores
- Cliff's delta with Romano et al. (2006) effect-size labels: negligible / small / medium / large
- **Per-metric ablation**: same comparison run on ROUGE-L, raw cosine, and calibrated cosine separately so the paper can attribute GA's wins to specific aspects of summary quality
- "Winning" generation per trial = the row with `max(best_blended)`; per-metric values come from that row (not max across metrics independently — that would be cherry-picking)

## Test plan
- [x] `pytest tests/test_stats.py tests/test_experiment.py tests/test_analysis.py tests/test_ga.py tests/test_random_search.py tests/test_fitness.py tests/test_prompt.py` — 99 passed locally
- [x] Real end-to-end: run `scripts/run_experiment.py --trials 3` against OpenRouter as a smoke test before kicking off the full 10-trial experiment

## Closes the assignment loop
With this merged the path is: tune `config.yaml` → run the experiment → write the paper from `statistical_summary.json` + `convergence.png`. No remaining blocking issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)